### PR TITLE
OpenH-RF proposal + full dataset catalog 

### DIFF
--- a/examples/dataset_catalog_previews/dataset_preview_beamform.m
+++ b/examples/dataset_catalog_previews/dataset_preview_beamform.m
@@ -339,8 +339,22 @@ switch fn
         pipe.scan = scan;
         b_data = pipe.go({midprocess.das() postprocess.coherent_compounding()});
 
+    case 'test02.uff'
+        % examples/uff/CPWC_UFF_read.m — beamforming uses /scan from file (same as stored b_data)
+        channel_data = uff.read_object(uff_file, '/channel_data');
+        scan = uff.read_object(uff_file, '/scan');
+        mid = midprocess.das();
+        mid.dimension = dimension.both;
+        mid.channel_data = channel_data;
+        mid.scan = scan;
+        mid.transmit_apodization.window = uff.window.tukey50;
+        mid.transmit_apodization.f_number = 1.0;
+        mid.receive_apodization.window = uff.window.tukey50;
+        mid.receive_apodization.f_number = 1.0;
+        b_data = mid.go();
+
     case 'speckle_sim_FI_P4_probe_apod_3_speckle_long_many_angles.uff'
-        % publications/TUSON/Vralstad_et_al_2026_.../Correction_of_simulated_blockage.m (RTB block)
+        % publications/.../Correction_of_simulated_blockage.m (RTB block)
         channel_data = uff.read_object(uff_file, '/channel_data');
         channel_data.data = channel_data.data ./ max(channel_data.data(:));
         depth_axis = linspace(0e-3, 110e-3, 512).';
@@ -494,7 +508,7 @@ switch fn
         pipe.receive_apodization.window = uff.window.none;
         b_data = pipe.go({midprocess.das()});
 
-    case 'P4_FI_121444_45mm_focus.uff'
+    case 'P4_FI.uff'
         % publications/IUS2018/.../FI_UFF_phased_array_MLA_and_RTB_delay_models.m (conventional)
         channel_data = uff.read_object(uff_file, '/channel_data');
         scan = uff.sector_scan('azimuth_axis', ...
@@ -516,10 +530,52 @@ switch fn
     case 'beamformed_experimental_data.uff'
         b_data = uff.read_object(uff_file, '/b_data_das');
 
+    case 'beamformed_simulated_data.uff'
+        b_data = uff.read_object(uff_file, '/b_data_das');
+
+    case 'reference_RTB_data.uff'
+        b_data = uff.read_object(uff_file, '/b_data');
+
     otherwise
-        error('dataset_preview_beamform:noCase', ...
-            'No preview recipe for %s — add a case in dataset_preview_beamform.m', fn);
+        b_data = generic_beamform(uff_file);
 end
+end
+
+function b_data = generic_beamform(uff_file)
+%GENERIC_BEAMFORM  Auto-detect scan type and beamform with standard parameters.
+channel_data = uff.read_object(uff_file, '/channel_data');
+
+% Detect sector vs linear: if source has non-zero azimuth, use sector scan
+is_sector = false;
+if ~isempty(channel_data.sequence(1).source) && ...
+        ~isempty(channel_data.sequence(1).source.azimuth) && ...
+        abs(channel_data.sequence(1).source.azimuth) > 0.01
+    is_sector = true;
+end
+
+if is_sector
+    az = zeros(channel_data.N_waves, 1);
+    for n = 1:channel_data.N_waves
+        az(n) = channel_data.sequence(n).source.azimuth;
+    end
+    scan = uff.sector_scan('azimuth_axis', az, ...
+        'depth_axis', linspace(0, 110e-3, 512).');
+else
+    x_range = max(channel_data.probe.x) - min(channel_data.probe.x);
+    scan = uff.linear_scan(...
+        'x_axis', linspace(-x_range*0.8, x_range*0.8, 256).', ...
+        'z_axis', linspace(1e-3, 55e-3, 512).');
+end
+
+mid = midprocess.das();
+mid.channel_data = channel_data;
+mid.dimension = dimension.both();
+mid.scan = scan;
+mid.receive_apodization.window = uff.window.hanning;
+mid.receive_apodization.f_number = 1.75;
+mid.transmit_apodization.window = uff.window.hanning;
+mid.transmit_apodization.f_number = 1.75;
+b_data = mid.go();
 end
 
 function ch = channel_data_from(uff_file)

--- a/examples/dataset_catalog_previews/export_png_like_b_data_plot.m
+++ b/examples/dataset_catalog_previews/export_png_like_b_data_plot.m
@@ -26,19 +26,19 @@ try
 
     ax = gca(fig);
     axis(ax, 'tight');
+    set(fig, 'Position', [100, 100, 600, 500]);
+    set(ax, 'Units', 'normalized', 'Position', [0.1, 0.1, 0.8, 0.8]);
     drawnow;
 
-    % Capture axes only (sector pcolor + equal aspect); avoids flat-matrix stretch.
+    % Capture figure (not just axes — avoids getframe zero-pixel errors in software OpenGL).
     if exist('exportgraphics', 'file') == 2 %#ok<EXIST>
         try
             exportgraphics(ax, filepath, 'Resolution', 120, 'BackgroundColor', 'white');
         catch
-            F = getframe(ax);
-            imwrite(F.cdata, filepath);
+            print(fig, filepath, '-dpng', '-r120');
         end
     else
-        F = getframe(ax);
-        imwrite(F.cdata, filepath);
+        print(fig, filepath, '-dpng', '-r120');
     end
 
     % Cap longest edge for the catalog (keep aspect from plot).

--- a/examples/dataset_smoke_tests/export_dataset_previews_to_website.m
+++ b/examples/dataset_smoke_tests/export_dataset_previews_to_website.m
@@ -13,7 +13,7 @@ function results = export_dataset_previews_to_website(varargin)
 %   naming as website/scripts/build_datasets_page.py (see website_slug_for_dataset).
 %
 %   Name-value:
-%     'url'              — primary dataset base (default Zenodo 20261898,
+%     'url'              — primary dataset base (default 'https://www.ustb.no/datasets',
 %                          no trailing slash)
 %     'stop_on_error'    — default false
 %     'website_root'     — override path to repo root (default: ustb_path())
@@ -29,7 +29,7 @@ function results = export_dataset_previews_to_website(varargin)
 %     python3 website/scripts/build_datasets_page.py
 
 p = inputParser;
-addParameter(p, 'url', tools.zenodo_dataset_files_base(), @(s) ischar(s) || isstring(s));
+addParameter(p, 'url', 'https://www.ustb.no/datasets', @(s) ischar(s) || isstring(s));
 addParameter(p, 'stop_on_error', false, @islogical);
 addParameter(p, 'website_root', '', @(s) ischar(s) || isstring(s));
 addParameter(p, 'indices', [], @(x) isempty(x) || (isnumeric(x) && isvector(x) && all(x > 0)));
@@ -107,7 +107,14 @@ for i = 1:n
         end
     end
     try
-        b_data = dataset_preview_beamform(uff_file);
+        if strcmp(T(i).mode, 'beamformed_only')
+            b_data = uff.read_object(uff_file, '/b_data');
+            if isempty(b_data) || isempty(b_data.data)
+                b_data = uff.read_object(uff_file, '/b_data_das');
+            end
+        else
+            b_data = dataset_preview_beamform(uff_file);
+        end
     catch ME
         results(i).message = ME.message;
         fprintf('[FAIL] %s — %s\n', fn, ME.message);
@@ -168,7 +175,11 @@ end
 function C = dataset_url_bases(primary)
 bases = {
     primary
-    tools.zenodo_dataset_files_base()
+    'https://www.ustb.no/datasets'
+    'http://www.ustb.no/datasets'
+    'https://ustb.no/datasets'
+    'http://ustb.no/datasets'
+    'https://www.ultrasoundtoolbox.com/datasets'
     };
 C = {};
 for k = 1:numel(bases)

--- a/examples/dataset_smoke_tests/uff_dataset_registry.m
+++ b/examples/dataset_smoke_tests/uff_dataset_registry.m
@@ -2,7 +2,7 @@ function T = uff_dataset_registry()
 %UFF_DATASET_REGISTRY  Table of UFF datasets referenced under examples/ and publications/.
 %
 %   Each row describes one distinct dataset file available from the USTB dataset
-%   repository (Zenodo record 20261898). Used by RUN_DATASET_SMOKE_TESTS.
+%   repository (ustb.no/datasets). Used by RUN_DATASET_SMOKE_TESTS.
 %
 %   Columns (struct fields):
 %     filename   - .uff file name
@@ -19,7 +19,7 @@ function T = uff_dataset_registry()
 
 T = struct('filename', {}, 'channel_h5', {}, 'mode', {}, 'note', {});
 
-% --- examples/ (Zenodo 20261898) ---
+% --- examples/ (ustb.no/datasets) ---
 T = add(T, 'Verasonics_P2-4_parasternal_long_small.uff', '', 'beamform', 'examples: FI phased array, minimal_example');
 T = add(T, 'L7_FI_IUS2018.uff', '', 'beamform', 'examples: FI RTB / Verasonics');
 T = add(T, 'L7_CPWC_193328.uff', '', 'beamform', 'examples: CPWC Verasonics');
@@ -33,13 +33,39 @@ T = add(T, 'ARFI_dataset.uff', '', 'beamform', 'examples: ARFI Verasonics');
 T = add(T, 'PICMUS_experiment_resolution_distortion.uff', '', 'beamform', 'examples: PICMUS');
 T = add(T, 'PICMUS_simulation_resolution_distortion.uff', '', 'beamform', 'examples: PICMUS');
 T = add(T, 'PICMUS_experiment_contrast_speckle.uff', '', 'beamform', 'examples: PICMUS');
-T = add(T, 'PICMUS_simulation_contrast_speckle.uff', '', 'beamform', 'examples: PICMUS, CPWC_UFF_read');
+T = add(T, 'PICMUS_simulation_contrast_speckle.uff', '', 'beamform', 'examples: PICMUS');
 T = add(T, 'PICMUS_carotid_cross.uff', '', 'beamform', 'examples: PICMUS in-vivo');
 T = add(T, 'Verasonics_P2-4_parasternal_long_subject_1.uff', '', 'beamform', 'examples: SLSC / multi-frame');
 T = add(T, 'FieldII_P4_point_scatterers.uff', '', 'beamform', 'examples: UiO phased array exercise');
 T = add(T, 'experimental_STAI_dynamic_range.uff', '/channel_data', 'beamform', 'examples: UiO STAI sandbox');
 T = add(T, 'P4_FI_121444_45mm_focus.uff', '', 'beamform', 'examples: REFoCUS');
 T = add(T, 'FieldII_speckle_simulation.uff', '', 'beamform', 'examples: field_II STAI speckle parfor');
+
+% --- additional Zenodo datasets (not yet referenced in examples/) ---
+T = add(T, 'Alpinion_L3-8_CPWC_hypoechoic.uff', '', 'beamform', 'Alpinion CPWC hypoechoic phantom');
+T = add(T, 'FI_P4_cysts_center.uff', '', 'beamform', 'Field II P4 phased array cyst simulation');
+T = add(T, 'FI_P4_point_scatterers.uff', '', 'beamform', 'Field II P4 phased array point scatterers');
+T = add(T, 'FieldII_CPWC_simulation_v2.uff', '', 'beamform', 'Field II CPWC simulation');
+T = add(T, 'FieldII_STAI_simulated_dynamic_range.uff', '', 'beamform', 'Field II STAI simulated dynamic range');
+T = add(T, 'FieldII_speckle_DMASsimulation300000pts.uff', '', 'beamform', 'Field II DMAS speckle simulation');
+T = add(T, 'L7_DW_TheGB.uff', '', 'beamform', 'L7-4 diverging wave (Generalized Beamformer)');
+T = add(T, 'L7_FI_TheGB.uff', '', 'beamform', 'L7-4 focused imaging (Generalized Beamformer)');
+T = add(T, 'L7_FI_Verasonics.uff', '', 'beamform', 'L7-4 focused imaging Verasonics');
+T = add(T, 'L7_FI_Verasonics_CIRS.uff', '', 'beamform', 'L7-4 focused imaging Verasonics CIRS');
+T = add(T, 'L7_FI_carotid_cross_1.uff', '', 'beamform', 'L7-4 in-vivo carotid cross-section');
+T = add(T, 'L7_FI_carotid_cross_2.uff', '', 'beamform', 'L7-4 in-vivo carotid cross-section');
+T = add(T, 'L7_STA_TheGB.uff', '', 'beamform', 'L7-4 synthetic transmit aperture (Generalized Beamformer)');
+T = add(T, 'PICMUS_carotid_long.uff', '', 'beamform', 'PICMUS in-vivo carotid longitudinal');
+T = add(T, 'PICMUS_numerical_calib_v2.uff', '', 'beamform', 'PICMUS numerical calibration');
+T = add(T, 'STAI_UFF_CIRS_phantom.uff', '', 'beamform', 'STAI CIRS phantom');
+T = add(T, 'SWE_L7_type_I.uff', '', 'beamform', 'Shear wave elastography type I');
+T = add(T, 'SWE_L7_type_III.uff', '', 'beamform', 'Shear wave elastography type III');
+T = add(T, 'SWE_L7_type_IV.uff', '', 'beamform', 'Shear wave elastography type IV');
+T = add(T, 'Verasonics_P2-4_apical_four_chamber_subject_1.uff', '', 'beamform', 'In-vivo cardiac apical four-chamber');
+T = add(T, 'experimental_dynamic_range_phantom.uff', '', 'beamform', 'Experimental dynamic range phantom');
+T = add(T, 'reference_RTB_data.uff', '', 'beamformed_only', 'RTB reference data (beamformed only)');
+T = add(T, 'speckle_sim_FI_P4_probe_apod_1_speckle_long_many_angles.uff', '', 'beamform', 'publications: Vralstad full aperture');
+T = add(T, 'speckle_sim_FI_P4_probe_apod_2_speckle_long_many_angles.uff', '', 'beamform', 'publications: Vralstad 1/3 blocked');
 
 % --- publications/ (Zenodo 20261898) ---
 T = add(T, 'speckle_sim_FI_P4_probe_apod_3_speckle_long_many_angles.uff', '', 'beamform', 'publications: Vralstad blockage');
@@ -49,7 +75,6 @@ T = add(T, 'invitro_20.uff', '', 'beamform', 'publications: TUFFC GCNR');
 T = add(T, 'insilico_side_100_M45.uff', '', 'beamform', 'publications: TUFFC GCNR');
 T = add(T, 'insilico_20.uff', '', 'beamform', 'publications: IUS2019 GCNR NLM');
 T = add(T, 'FieldII_CPWC_point_scatterers_res_v2.uff', '', 'beamform', 'publications: IUS2020 resolution');
-T = add(T, 'P4_FI_121444_45mm_focus.uff', '', 'beamform', 'publications: IUS2018 MLA/RTB');
 T = add(T, 'beamformed_simulated_data.uff', '', 'beamformed_only', 'publications: IUS2017 dark region (beamformed only)');
 T = add(T, 'beamformed_experimental_data.uff', '', 'beamformed_only', 'publications: IUS2017 dark region (beamformed only)');
 

--- a/sandbox/OpenHRF/README.md
+++ b/sandbox/OpenHRF/README.md
@@ -1,0 +1,48 @@
+# OpenH-RF Contribution: USTB Datasets
+
+This folder contains the proposal and conversion tools for contributing
+USTB (UltraSound ToolBox) datasets to the
+[OpenH-RF](https://github.com/open-h/OpenH-RF) initiative.
+
+## Contents
+
+| File | Description |
+|------|-------------|
+| `proposal.tex` | 2-page LaTeX proposal for the OpenH-RF RFP |
+| `convert_ustb_to_openh_rf.py` | Python script: UFF → zea HDF5 conversion |
+| `generate_labels.m` | MATLAB script: DAS beamforming labels for all datasets |
+
+## Quick start
+
+### Build the proposal PDF
+
+```bash
+cd sandbox/OpenHRF
+pdflatex proposal.tex
+```
+
+### Convert datasets
+
+```bash
+pip install pyuff-ustb zea numpy
+python convert_ustb_to_openh_rf.py --zenodo --output openh_rf/
+```
+
+### Generate labels (MATLAB)
+
+```matlab
+addpath(genpath(ustb_path()));
+run('sandbox/OpenHRF/generate_labels.m');
+```
+
+## Dataset source
+
+All 53 datasets are hosted on Zenodo:
+- **Record 20261898**: https://zenodo.org/records/20261898
+- **License**: MIT (code), CC BY 4.0 (data contribution to OpenH-RF)
+
+## Links
+
+- OpenH-RF RFP: https://github.com/open-h/OpenH-RF
+- USTB: https://github.com/unioslo/USTB
+- USTB website: https://www.ultrasoundtoolbox.com

--- a/sandbox/OpenHRF/convert_ustb_to_openh_rf.py
+++ b/sandbox/OpenHRF/convert_ustb_to_openh_rf.py
@@ -1,0 +1,250 @@
+"""Convert USTB UFF datasets to OpenH-RF (zea) HDF5 format.
+
+Reads .uff files from Zenodo (or local cache) via pyuff-ustb and writes
+.hdf5 files using the zea library in the OpenH-RF data format.
+
+Usage:
+    python convert_ustb_to_openh_rf.py --input data/ --output openh_rf/
+    python convert_ustb_to_openh_rf.py --zenodo --output openh_rf/
+
+Requirements:
+    pip install pyuff-ustb zea numpy
+"""
+
+import argparse
+import os
+from pathlib import Path
+
+import numpy as np
+
+ZENODO_RECORD = "20261898"
+ZENODO_BASE = f"https://zenodo.org/records/{ZENODO_RECORD}/files"
+
+DATASETS = [
+    # In-vivo human (cardiac, phased array P2-4)
+    {"filename": "Verasonics_P2-4_parasternal_long_subject_1.uff", "probe": "P2-4", "tier": "in-vivo-human", "anatomy": "heart", "view": "parasternal long"},
+    {"filename": "Verasonics_P2-4_parasternal_long_small.uff", "probe": "P2-4", "tier": "in-vivo-human", "anatomy": "heart", "view": "parasternal long"},
+    {"filename": "Verasonics_P2-4_apical_four_chamber_subject_1.uff", "probe": "P2-4", "tier": "in-vivo-human", "anatomy": "heart", "view": "apical four-chamber"},
+    # In-vivo human (carotid, linear array L7-4)
+    {"filename": "L7_FI_carotid_cross_1.uff", "probe": "L7-4", "tier": "in-vivo-human", "anatomy": "carotid", "view": "cross-section"},
+    {"filename": "L7_FI_carotid_cross_2.uff", "probe": "L7-4", "tier": "in-vivo-human", "anatomy": "carotid", "view": "cross-section"},
+    {"filename": "L7_FI_carotid_cross_sub_2.uff", "probe": "L7-4", "tier": "in-vivo-human", "anatomy": "carotid", "view": "cross-section"},
+    {"filename": "PICMUS_carotid_long.uff", "probe": "L7-4", "tier": "in-vivo-human", "anatomy": "carotid", "view": "longitudinal"},
+    {"filename": "PICMUS_carotid_cross.uff", "probe": "L7-4", "tier": "in-vivo-human", "anatomy": "carotid", "view": "cross-section"},
+    # Phantom (CIRS, tissue-mimicking)
+    {"filename": "PICMUS_experiment_resolution_distortion.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "CIRS phantom", "view": "resolution"},
+    {"filename": "PICMUS_experiment_contrast_speckle.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "CIRS phantom", "view": "contrast"},
+    {"filename": "experimental_STAI_dynamic_range.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "phantom", "view": "dynamic range"},
+    {"filename": "experimental_dynamic_range_phantom.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "phantom", "view": "dynamic range"},
+    {"filename": "STAI_UFF_CIRS_phantom.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "CIRS phantom", "view": "STA"},
+    {"filename": "L7_CPWC_193328.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "phantom", "view": "CPWC"},
+    {"filename": "L7_FI_IUS2018.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "phantom", "view": "focused imaging"},
+    {"filename": "L7_FI_Verasonics.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "phantom", "view": "focused imaging"},
+    {"filename": "L7_FI_Verasonics_CIRS.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "CIRS phantom", "view": "focused imaging"},
+    {"filename": "L7_FI_Verasonics_CIRS_points.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "CIRS phantom", "view": "point targets"},
+    {"filename": "Alpinion_L3-8_FI_hypoechoic.uff", "probe": "L3-8", "tier": "phantom", "anatomy": "phantom", "view": "hypoechoic cyst"},
+    {"filename": "Alpinion_L3-8_FI_hyperechoic_scatterers.uff", "probe": "L3-8", "tier": "phantom", "anatomy": "phantom", "view": "hyperechoic scatterers"},
+    {"filename": "Alpinion_L3-8_CPWC_hypoechoic.uff", "probe": "L3-8", "tier": "phantom", "anatomy": "phantom", "view": "CPWC hypoechoic"},
+    {"filename": "Alpinion_L3-8_CPWC_hyperechoic_scatterers.uff", "probe": "L3-8", "tier": "phantom", "anatomy": "phantom", "view": "CPWC hyperechoic"},
+    {"filename": "ARFI_dataset.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "phantom", "view": "ARFI push"},
+    {"filename": "SWE_L7_type_I.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "elastography phantom", "view": "shear wave"},
+    {"filename": "SWE_L7_type_III.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "elastography phantom", "view": "shear wave"},
+    {"filename": "SWE_L7_type_IV.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "elastography phantom", "view": "shear wave"},
+    {"filename": "reference_RTB_data.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "phantom", "view": "RTB reference"},
+    {"filename": "P4_FI_121444_45mm_focus.uff", "probe": "P4-1", "tier": "phantom", "anatomy": "phantom", "view": "focused phased array"},
+    # Simulation (Field II)
+    {"filename": "PICMUS_simulation_resolution_distortion.uff", "probe": "L7-4", "tier": "simulation", "anatomy": "simulated", "view": "resolution"},
+    {"filename": "PICMUS_simulation_contrast_speckle.uff", "probe": "L7-4", "tier": "simulation", "anatomy": "simulated", "view": "contrast"},
+    {"filename": "PICMUS_numerical_calib_v2.uff", "probe": "L7-4", "tier": "simulation", "anatomy": "simulated", "view": "calibration"},
+    {"filename": "FieldII_CPWC_simulation_v2.uff", "probe": "L7-4", "tier": "simulation", "anatomy": "simulated", "view": "CPWC"},
+    {"filename": "FieldII_CPWC_point_scatterers_res_v2.uff", "probe": "L7-4", "tier": "simulation", "anatomy": "simulated", "view": "point scatterers"},
+    {"filename": "FieldII_STAI_dynamic_range.uff", "probe": "L7-4", "tier": "simulation", "anatomy": "simulated", "view": "dynamic range"},
+    {"filename": "FieldII_STAI_simulated_dynamic_range.uff", "probe": "L7-4", "tier": "simulation", "anatomy": "simulated", "view": "dynamic range"},
+    {"filename": "FieldII_STAI_uniform_fov.uff", "probe": "L7-4", "tier": "simulation", "anatomy": "simulated", "view": "uniform FOV"},
+    {"filename": "FieldII_P4_point_scatterers.uff", "probe": "P4-1", "tier": "simulation", "anatomy": "simulated", "view": "point scatterers"},
+    {"filename": "FI_P4_point_scatterers.uff", "probe": "P4-1", "tier": "simulation", "anatomy": "simulated", "view": "point scatterers"},
+    {"filename": "FI_P4_cysts_center.uff", "probe": "P4-1", "tier": "simulation", "anatomy": "simulated", "view": "cyst"},
+    {"filename": "FieldII_speckle_simulation.uff", "probe": "L7-4", "tier": "simulation", "anatomy": "simulated", "view": "speckle"},
+    {"filename": "FieldII_speckle_DMASsimulation300000pts.uff", "probe": "L7-4", "tier": "simulation", "anatomy": "simulated", "view": "DMAS speckle"},
+    {"filename": "speckle_sim_FI_P4_probe_apod_1_speckle_long_many_angles.uff", "probe": "P4-1", "tier": "simulation", "anatomy": "simulated", "view": "blocked array (full)"},
+    {"filename": "speckle_sim_FI_P4_probe_apod_2_speckle_long_many_angles.uff", "probe": "P4-1", "tier": "simulation", "anatomy": "simulated", "view": "blocked array (1/3)"},
+    {"filename": "speckle_sim_FI_P4_probe_apod_3_speckle_long_many_angles.uff", "probe": "P4-1", "tier": "simulation", "anatomy": "simulated", "view": "blocked array (1/2)"},
+    # Generalized Beamformer datasets
+    {"filename": "L7_CPWC_TheGB.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "phantom", "view": "CPWC"},
+    {"filename": "L7_FI_TheGB.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "phantom", "view": "focused imaging"},
+    {"filename": "L7_DW_TheGB.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "phantom", "view": "diverging wave"},
+    {"filename": "L7_STA_TheGB.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "phantom", "view": "synthetic transmit aperture"},
+    # Large in-vivo
+    {"filename": "invitro_20.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "tissue phantom", "view": "in-vitro"},
+    {"filename": "insilico_20.uff", "probe": "L7-4", "tier": "simulation", "anatomy": "simulated", "view": "in-silico"},
+    {"filename": "insilico_side_100_M45.uff", "probe": "L7-4", "tier": "simulation", "anatomy": "simulated", "view": "in-silico side"},
+    {"filename": "beamformed_simulated_data.uff", "probe": "L7-4", "tier": "simulation", "anatomy": "simulated", "view": "DRA beamformed"},
+    {"filename": "beamformed_experimental_data.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "phantom", "view": "DRA beamformed"},
+]
+
+
+def download_if_missing(filename: str, data_dir: Path) -> Path:
+    """Download .uff from Zenodo if not cached locally."""
+    import urllib.request
+
+    filepath = data_dir / filename
+    if filepath.exists():
+        return filepath
+    data_dir.mkdir(parents=True, exist_ok=True)
+    url = f"{ZENODO_BASE}/{filename}"
+    print(f"Downloading {url} ...")
+    urllib.request.urlretrieve(url, filepath)
+    return filepath
+
+
+def read_uff_channel_data(filepath: Path):
+    """Read channel_data from a UFF file using pyuff-ustb."""
+    from pyuff_ustb.objects.uff import Uff
+
+    uff_file = Uff(str(filepath))
+    try:
+        return uff_file.read("channel_data")
+    except Exception:
+        return None
+
+
+def uff_to_zea_scan(channel_data) -> dict:
+    """Map pyuff-ustb ChannelData to a zea-compatible scan dictionary."""
+    probe = channel_data.probe
+    sequence = channel_data.sequence
+
+    n_el = int(probe.N_elements)
+    probe_geometry = np.zeros((n_el, 3), dtype=np.float32)
+    probe_geometry[:, 0] = np.array(probe.x, dtype=np.float32).flatten()
+    if hasattr(probe, 'y') and probe.y is not None:
+        probe_geometry[:, 1] = np.array(probe.y, dtype=np.float32).flatten()
+    if hasattr(probe, 'z') and probe.z is not None:
+        probe_geometry[:, 2] = np.array(probe.z, dtype=np.float32).flatten()
+
+    n_tx = len(sequence)
+    sampling_frequency = float(channel_data.sampling_frequency)
+    sound_speed = float(channel_data.sound_speed)
+
+    polar_angles = np.zeros(n_tx, dtype=np.float32)
+    azimuth_angles = np.zeros(n_tx, dtype=np.float32)
+    focus_distances = np.full(n_tx, np.inf, dtype=np.float32)
+    initial_times = np.zeros(n_tx, dtype=np.float32)
+
+    for i, wave in enumerate(sequence):
+        src = wave.source
+        if hasattr(src, 'azimuth') and src.azimuth is not None:
+            polar_angles[i] = float(src.azimuth)
+        if hasattr(src, 'elevation') and src.elevation is not None:
+            azimuth_angles[i] = float(src.elevation)
+        if hasattr(src, 'distance') and src.distance is not None:
+            focus_distances[i] = float(src.distance)
+        if hasattr(wave, 'delay') and wave.delay is not None:
+            initial_times[i] = float(wave.delay)
+
+    center_frequency = 0.0
+    if hasattr(channel_data, 'pulse') and channel_data.pulse is not None:
+        if hasattr(channel_data.pulse, 'center_frequency'):
+            center_frequency = float(channel_data.pulse.center_frequency or 0)
+
+    scan = {
+        "probe_geometry": probe_geometry,
+        "sampling_frequency": sampling_frequency,
+        "center_frequency": center_frequency,
+        "initial_times": initial_times,
+        "t0_delays": np.zeros((n_tx, n_el), dtype=np.float32),
+        "tx_apodizations": np.ones((n_tx, n_el), dtype=np.float32),
+        "focus_distances": focus_distances,
+        "transmit_origins": np.zeros((n_tx, 3), dtype=np.float32),
+        "polar_angles": polar_angles,
+        "azimuth_angles": azimuth_angles,
+        "sound_speed": sound_speed,
+    }
+    return scan
+
+
+def convert_dataset(filepath: Path, output_dir: Path, meta: dict) -> bool:
+    """Convert a single UFF file to OpenH-RF zea HDF5."""
+    from zea import File
+
+    channel_data = read_uff_channel_data(filepath)
+    if channel_data is None:
+        print(f"  SKIP (no channel_data): {filepath.name}")
+        return False
+
+    raw = np.array(channel_data.data, dtype=np.float32)
+    # UFF shape: [samples, channels, waves, frames] -> [frames, tx, samples, elements, 1]
+    if raw.ndim == 4:
+        raw = raw.transpose(3, 2, 0, 1)  # [frames, waves, samples, channels]
+    elif raw.ndim == 3:
+        raw = raw.transpose(2, 0, 1)  # [waves, samples, channels]
+        raw = raw[np.newaxis, ...]  # [1, waves, samples, channels]
+    else:
+        print(f"  SKIP (unexpected shape {raw.shape}): {filepath.name}")
+        return False
+
+    raw = raw[..., np.newaxis]  # add trailing dim -> [frames, tx, samples, el, 1]
+
+    scan = uff_to_zea_scan(channel_data)
+    output_path = output_dir / filepath.with_suffix(".hdf5").name
+
+    metadata = {
+        "annotations": {
+            "anatomy": meta.get("anatomy", ""),
+            "view": meta.get("view", ""),
+        },
+        "credit": "USTB - UltraSound ToolBox (University of Oslo)",
+        "subject": {"type": meta.get("tier", "unknown")},
+    }
+
+    File.create(
+        path=str(output_path),
+        data={"raw_data": raw},
+        scan=scan,
+        metadata=metadata,
+        probe_name=meta.get("probe", "unknown"),
+        us_machine="Verasonics / Alpinion / Field II simulation",
+        description=f"USTB dataset: {filepath.stem}. {meta.get('view', '')}. "
+                    f"Tier: {meta.get('tier', '')}.",
+    )
+    print(f"  OK: {output_path.name} ({raw.shape})")
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert USTB UFF to OpenH-RF")
+    parser.add_argument("--input", type=str, default="data",
+                        help="Directory with local .uff files")
+    parser.add_argument("--output", type=str, default="openh_rf",
+                        help="Output directory for .hdf5 files")
+    parser.add_argument("--zenodo", action="store_true",
+                        help="Download from Zenodo if file not in --input")
+    parser.add_argument("--limit", type=int, default=0,
+                        help="Limit number of datasets to convert (0=all)")
+    args = parser.parse_args()
+
+    data_dir = Path(args.input)
+    output_dir = Path(args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    datasets = DATASETS[:args.limit] if args.limit > 0 else DATASETS
+    ok_count = 0
+
+    for meta in datasets:
+        fn = meta["filename"]
+        filepath = data_dir / fn
+        if not filepath.exists() and args.zenodo:
+            filepath = download_if_missing(fn, data_dir)
+        if not filepath.exists():
+            print(f"  MISSING: {fn}")
+            continue
+        try:
+            if convert_dataset(filepath, output_dir, meta):
+                ok_count += 1
+        except Exception as e:
+            print(f"  ERROR ({fn}): {e}")
+
+    print(f"\nConverted {ok_count}/{len(datasets)} datasets to {output_dir}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/sandbox/OpenHRF/convert_ustb_to_openh_rf_matlab.m
+++ b/sandbox/OpenHRF/convert_ustb_to_openh_rf_matlab.m
@@ -1,0 +1,257 @@
+%% Convert USTB UFF datasets to OpenH-RF (zea) HDF5 format — MATLAB version
+%
+% Reads .uff files from Zenodo via tools.download and writes .hdf5 files
+% in the OpenH-RF / zea data format.
+%
+% The zea HDF5 format stores:
+%   /data/raw_data          — [frames, tx, samples, elements, 1] float32
+%   /scan/probe_geometry    — [elements, 3] float32
+%   /scan/sampling_frequency — scalar
+%   /scan/center_frequency  — scalar
+%   /scan/sound_speed       — scalar
+%   /scan/polar_angles      — [tx, 1] float32
+%   /scan/azimuth_angles    — [tx, 1] float32
+%   /scan/focus_distances   — [tx, 1] float32
+%   /scan/initial_times     — [tx, 1] float32
+%   /scan/t0_delays         — [tx, elements] float32
+%   /scan/tx_apodizations   — [tx, elements] float32
+%   /scan/transmit_origins  — [tx, 3] float32
+%   /metadata/probe_name    — string
+%   /metadata/us_machine    — string
+%   /metadata/description   — string
+%   /metadata/credit        — string
+%
+% Usage:
+%   addpath(genpath(ustb_path()));
+%   run('sandbox/OpenHRF/convert_ustb_to_openh_rf_matlab.m');
+%
+% Or call the function directly:
+%   convert_ustb_to_openh_rf_matlab('output_dir', './openh_rf_hdf5');
+
+function convert_ustb_to_openh_rf_matlab(varargin)
+
+p = inputParser;
+addParameter(p, 'output_dir', fullfile(fileparts(mfilename('fullpath')), 'openh_rf_hdf5'), @ischar);
+addParameter(p, 'limit', 0, @isnumeric);
+parse(p, varargin{:});
+
+output_dir = p.Results.output_dir;
+limit = p.Results.limit;
+
+if ~isfolder(output_dir)
+    mkdir(output_dir);
+end
+
+url = tools.zenodo_dataset_files_base();
+local_path = data_path();
+
+datasets = get_dataset_list();
+if limit > 0
+    datasets = datasets(1:min(limit, numel(datasets)));
+end
+
+fprintf('=== USTB → OpenH-RF (zea HDF5) Conversion ===\n');
+fprintf('Output: %s\n', output_dir);
+fprintf('Datasets: %d\n\n', numel(datasets));
+
+ok_count = 0;
+for k = 1:numel(datasets)
+    ds = datasets(k);
+    fn = ds.filename;
+    fprintf('[%02d/%02d] %s ... ', k, numel(datasets), fn);
+
+    try
+        tools.download(fn, url, local_path);
+        uff_file = fullfile(local_path, fn);
+
+        channel_data = uff.read_object(uff_file, '/channel_data');
+
+        out_file = fullfile(output_dir, strrep(fn, '.uff', '.hdf5'));
+        write_openh_rf_hdf5(out_file, channel_data, ds);
+
+        fprintf('OK\n');
+        ok_count = ok_count + 1;
+    catch ME
+        fprintf('FAILED: %s\n', ME.message);
+    end
+end
+
+fprintf('\n=== Done: %d/%d converted ===\n', ok_count, numel(datasets));
+end
+
+
+function write_openh_rf_hdf5(filepath, channel_data, meta)
+%WRITE_OPENH_RF_HDF5  Write a single dataset in zea/OpenH-RF HDF5 format.
+
+if isfile(filepath)
+    delete(filepath);
+end
+
+% --- raw_data: reshape from UFF [samples, channels, waves, frames]
+%               to zea [frames, tx, samples, elements, 1]
+raw = single(channel_data.data);
+sz = size(raw);
+n_samples = sz(1);
+n_channels = sz(2);
+n_tx = 1; if ndims(raw) >= 3, n_tx = sz(3); end
+n_frames = 1; if ndims(raw) >= 4, n_frames = sz(4); end
+
+% Permute: MATLAB [samples, channels, tx, frames] → [frames, tx, samples, channels]
+raw = permute(raw, [4, 3, 1, 2]);
+raw = reshape(raw, [n_frames, n_tx, n_samples, n_channels, 1]);
+
+h5create(filepath, '/data/raw_data', size(raw), 'Datatype', 'single');
+h5write(filepath, '/data/raw_data', raw);
+
+% --- scan parameters
+n_el = channel_data.probe.N_elements;
+probe_geom = zeros(n_el, 3, 'single');
+probe_geom(:, 1) = single(channel_data.probe.x(:));
+if ~isempty(channel_data.probe.y)
+    probe_geom(:, 2) = single(channel_data.probe.y(:));
+end
+if ~isempty(channel_data.probe.z)
+    probe_geom(:, 3) = single(channel_data.probe.z(:));
+end
+
+h5create(filepath, '/scan/probe_geometry', size(probe_geom), 'Datatype', 'single');
+h5write(filepath, '/scan/probe_geometry', probe_geom);
+
+h5create(filepath, '/scan/sampling_frequency', 1, 'Datatype', 'double');
+h5write(filepath, '/scan/sampling_frequency', channel_data.sampling_frequency);
+
+cf = 0;
+if ~isempty(channel_data.pulse) && isprop(channel_data.pulse, 'center_frequency')
+    cf = channel_data.pulse.center_frequency;
+    if isempty(cf), cf = 0; end
+end
+h5create(filepath, '/scan/center_frequency', 1, 'Datatype', 'double');
+h5write(filepath, '/scan/center_frequency', cf);
+
+h5create(filepath, '/scan/sound_speed', 1, 'Datatype', 'double');
+h5write(filepath, '/scan/sound_speed', channel_data.sound_speed);
+
+% Per-transmit parameters
+polar_angles = zeros(n_tx, 1, 'single');
+azimuth_angles = zeros(n_tx, 1, 'single');
+focus_distances = inf(n_tx, 1, 'single');
+initial_times = zeros(n_tx, 1, 'single');
+transmit_origins = zeros(n_tx, 3, 'single');
+
+for i = 1:n_tx
+    w = channel_data.sequence(i);
+    if ~isempty(w.source) && ~isempty(w.source.azimuth)
+        polar_angles(i) = single(w.source.azimuth);
+    end
+    if ~isempty(w.source) && isprop(w.source, 'elevation') && ~isempty(w.source.elevation)
+        azimuth_angles(i) = single(w.source.elevation);
+    end
+    if ~isempty(w.source) && ~isempty(w.source.distance)
+        focus_distances(i) = single(w.source.distance);
+    end
+    if ~isempty(w.delay)
+        initial_times(i) = single(w.delay);
+    end
+    if ~isempty(w.source)
+        transmit_origins(i, 1) = single(w.source.x);
+        transmit_origins(i, 2) = single(w.source.y);
+        transmit_origins(i, 3) = single(w.source.z);
+    end
+end
+
+h5create(filepath, '/scan/polar_angles', [n_tx, 1], 'Datatype', 'single');
+h5write(filepath, '/scan/polar_angles', polar_angles);
+h5create(filepath, '/scan/azimuth_angles', [n_tx, 1], 'Datatype', 'single');
+h5write(filepath, '/scan/azimuth_angles', azimuth_angles);
+h5create(filepath, '/scan/focus_distances', [n_tx, 1], 'Datatype', 'single');
+h5write(filepath, '/scan/focus_distances', focus_distances);
+h5create(filepath, '/scan/initial_times', [n_tx, 1], 'Datatype', 'single');
+h5write(filepath, '/scan/initial_times', initial_times);
+h5create(filepath, '/scan/transmit_origins', [n_tx, 3], 'Datatype', 'single');
+h5write(filepath, '/scan/transmit_origins', transmit_origins);
+
+% t0_delays and tx_apodizations (default: zeros / ones)
+h5create(filepath, '/scan/t0_delays', [n_tx, n_el], 'Datatype', 'single');
+h5write(filepath, '/scan/t0_delays', zeros(n_tx, n_el, 'single'));
+h5create(filepath, '/scan/tx_apodizations', [n_tx, n_el], 'Datatype', 'single');
+h5write(filepath, '/scan/tx_apodizations', ones(n_tx, n_el, 'single'));
+
+% --- metadata (as HDF5 attributes on root group)
+h5writeatt(filepath, '/', 'probe_name', meta.probe);
+h5writeatt(filepath, '/', 'us_machine', 'Verasonics / Alpinion / Field II simulation');
+h5writeatt(filepath, '/', 'description', ...
+    sprintf('USTB dataset: %s. %s. Tier: %s.', meta.filename, meta.view, meta.tier));
+h5writeatt(filepath, '/', 'credit', 'USTB - UltraSound ToolBox (University of Oslo)');
+h5writeatt(filepath, '/', 'anatomy', meta.anatomy);
+h5writeatt(filepath, '/', 'tier', meta.tier);
+
+end
+
+
+function datasets = get_dataset_list()
+%GET_DATASET_LIST  Return struct array of all USTB datasets for conversion.
+
+datasets = struct('filename', {}, 'probe', {}, 'tier', {}, 'anatomy', {}, 'view', {});
+
+datasets(end+1) = ds('Verasonics_P2-4_parasternal_long_subject_1.uff', 'P2-4', 'in-vivo-human', 'heart', 'parasternal long');
+datasets(end+1) = ds('Verasonics_P2-4_parasternal_long_small.uff', 'P2-4', 'in-vivo-human', 'heart', 'parasternal long');
+datasets(end+1) = ds('Verasonics_P2-4_apical_four_chamber_subject_1.uff', 'P2-4', 'in-vivo-human', 'heart', 'apical four-chamber');
+datasets(end+1) = ds('L7_FI_carotid_cross_1.uff', 'L7-4', 'in-vivo-human', 'carotid', 'cross-section');
+datasets(end+1) = ds('L7_FI_carotid_cross_2.uff', 'L7-4', 'in-vivo-human', 'carotid', 'cross-section');
+datasets(end+1) = ds('L7_FI_carotid_cross_sub_2.uff', 'L7-4', 'in-vivo-human', 'carotid', 'cross-section');
+datasets(end+1) = ds('PICMUS_carotid_long.uff', 'L7-4', 'in-vivo-human', 'carotid', 'longitudinal');
+datasets(end+1) = ds('PICMUS_carotid_cross.uff', 'L7-4', 'in-vivo-human', 'carotid', 'cross-section');
+datasets(end+1) = ds('PICMUS_experiment_resolution_distortion.uff', 'L7-4', 'phantom', 'CIRS phantom', 'resolution');
+datasets(end+1) = ds('PICMUS_experiment_contrast_speckle.uff', 'L7-4', 'phantom', 'CIRS phantom', 'contrast');
+datasets(end+1) = ds('experimental_STAI_dynamic_range.uff', 'L7-4', 'phantom', 'phantom', 'dynamic range');
+datasets(end+1) = ds('experimental_dynamic_range_phantom.uff', 'L7-4', 'phantom', 'phantom', 'dynamic range');
+datasets(end+1) = ds('STAI_UFF_CIRS_phantom.uff', 'L7-4', 'phantom', 'CIRS phantom', 'STA');
+datasets(end+1) = ds('L7_CPWC_193328.uff', 'L7-4', 'phantom', 'phantom', 'CPWC');
+datasets(end+1) = ds('L7_FI_IUS2018.uff', 'L7-4', 'phantom', 'phantom', 'focused imaging');
+datasets(end+1) = ds('L7_FI_Verasonics.uff', 'L7-4', 'phantom', 'phantom', 'focused imaging');
+datasets(end+1) = ds('L7_FI_Verasonics_CIRS.uff', 'L7-4', 'phantom', 'CIRS phantom', 'focused imaging');
+datasets(end+1) = ds('L7_FI_Verasonics_CIRS_points.uff', 'L7-4', 'phantom', 'CIRS phantom', 'point targets');
+datasets(end+1) = ds('Alpinion_L3-8_FI_hypoechoic.uff', 'L3-8', 'phantom', 'phantom', 'hypoechoic cyst');
+datasets(end+1) = ds('Alpinion_L3-8_FI_hyperechoic_scatterers.uff', 'L3-8', 'phantom', 'phantom', 'hyperechoic scatterers');
+datasets(end+1) = ds('Alpinion_L3-8_CPWC_hypoechoic.uff', 'L3-8', 'phantom', 'CPWC hypoechoic', 'CPWC');
+datasets(end+1) = ds('Alpinion_L3-8_CPWC_hyperechoic_scatterers.uff', 'L3-8', 'phantom', 'phantom', 'CPWC hyperechoic');
+datasets(end+1) = ds('ARFI_dataset.uff', 'L7-4', 'phantom', 'phantom', 'ARFI');
+datasets(end+1) = ds('SWE_L7_type_I.uff', 'L7-4', 'phantom', 'elastography phantom', 'shear wave');
+datasets(end+1) = ds('SWE_L7_type_III.uff', 'L7-4', 'phantom', 'elastography phantom', 'shear wave');
+datasets(end+1) = ds('SWE_L7_type_IV.uff', 'L7-4', 'phantom', 'elastography phantom', 'shear wave');
+datasets(end+1) = ds('reference_RTB_data.uff', 'L7-4', 'phantom', 'phantom', 'RTB reference');
+datasets(end+1) = ds('P4_FI_121444_45mm_focus.uff', 'P4-1', 'phantom', 'phantom', 'focused phased array');
+datasets(end+1) = ds('PICMUS_simulation_resolution_distortion.uff', 'L7-4', 'simulation', 'simulated', 'resolution');
+datasets(end+1) = ds('PICMUS_simulation_contrast_speckle.uff', 'L7-4', 'simulation', 'simulated', 'contrast');
+datasets(end+1) = ds('PICMUS_numerical_calib_v2.uff', 'L7-4', 'simulation', 'simulated', 'calibration');
+datasets(end+1) = ds('FieldII_CPWC_simulation_v2.uff', 'L7-4', 'simulation', 'simulated', 'CPWC');
+datasets(end+1) = ds('FieldII_CPWC_point_scatterers_res_v2.uff', 'L7-4', 'simulation', 'simulated', 'point scatterers');
+datasets(end+1) = ds('FieldII_STAI_dynamic_range.uff', 'L7-4', 'simulation', 'simulated', 'dynamic range');
+datasets(end+1) = ds('FieldII_STAI_simulated_dynamic_range.uff', 'L7-4', 'simulation', 'simulated', 'dynamic range');
+datasets(end+1) = ds('FieldII_STAI_uniform_fov.uff', 'L7-4', 'simulation', 'simulated', 'uniform FOV');
+datasets(end+1) = ds('FieldII_P4_point_scatterers.uff', 'P4-1', 'simulation', 'simulated', 'point scatterers');
+datasets(end+1) = ds('FI_P4_point_scatterers.uff', 'P4-1', 'simulation', 'simulated', 'point scatterers');
+datasets(end+1) = ds('FI_P4_cysts_center.uff', 'P4-1', 'simulation', 'simulated', 'cyst');
+datasets(end+1) = ds('FieldII_speckle_simulation.uff', 'L7-4', 'simulation', 'simulated', 'speckle');
+datasets(end+1) = ds('FieldII_speckle_DMASsimulation300000pts.uff', 'L7-4', 'simulation', 'simulated', 'DMAS speckle');
+datasets(end+1) = ds('speckle_sim_FI_P4_probe_apod_1_speckle_long_many_angles.uff', 'P4-1', 'simulation', 'simulated', 'blocked array (full)');
+datasets(end+1) = ds('speckle_sim_FI_P4_probe_apod_2_speckle_long_many_angles.uff', 'P4-1', 'simulation', 'simulated', 'blocked array (1/3)');
+datasets(end+1) = ds('speckle_sim_FI_P4_probe_apod_3_speckle_long_many_angles.uff', 'P4-1', 'simulation', 'simulated', 'blocked array (1/2)');
+datasets(end+1) = ds('L7_CPWC_TheGB.uff', 'L7-4', 'phantom', 'phantom', 'CPWC');
+datasets(end+1) = ds('L7_FI_TheGB.uff', 'L7-4', 'phantom', 'phantom', 'focused imaging');
+datasets(end+1) = ds('L7_DW_TheGB.uff', 'L7-4', 'phantom', 'phantom', 'diverging wave');
+datasets(end+1) = ds('L7_STA_TheGB.uff', 'L7-4', 'phantom', 'phantom', 'STA');
+datasets(end+1) = ds('invitro_20.uff', 'L7-4', 'phantom', 'tissue phantom', 'in-vitro');
+datasets(end+1) = ds('insilico_20.uff', 'L7-4', 'simulation', 'simulated', 'in-silico');
+datasets(end+1) = ds('insilico_side_100_M45.uff', 'L7-4', 'simulation', 'simulated', 'in-silico side');
+
+end
+
+
+function s = ds(filename, probe, tier, anatomy, view)
+s.filename = filename;
+s.probe = probe;
+s.tier = tier;
+s.anatomy = anatomy;
+s.view = view;
+end

--- a/sandbox/OpenHRF/form_answers.md
+++ b/sandbox/OpenHRF/form_answers.md
@@ -1,0 +1,118 @@
+# OpenH-RF Submission Form — Draft Answers
+
+Prepared for copy-paste into the Google Form at:
+https://docs.google.com/forms/d/e/1FAIpQLScbC1FEknFM0tNjKXh_lWi5u-Ly02WxhjK8uEDry1MatyCm7A/viewform
+
+---
+
+## Lead Contact
+
+**Name:** Ole Marius Hoel Rindal
+
+**Email:** olemarius@olemarius.net
+
+**Institution:** University of Oslo (UiO), Department of Informatics
+
+**Country:** Norway
+
+---
+
+## Proposal Title
+
+The UltraSound ToolBox (USTB) Channel Capture Dataset
+
+---
+
+## Executive Summary (≤500 words)
+
+We propose to contribute 53 pre-beamformed (channel capture) ultrasound datasets from the UltraSound ToolBox (USTB) initiative to OpenH-RF. The USTB is an open-source toolbox for ultrasound beamforming, processing, and visualization, maintained since 2017 at the University of Oslo and used widely in the ultrasound research community.
+
+The datasets span in-vivo human cardiac and carotid imaging, tissue-mimicking phantoms (CIRS), and physics-based Field II simulations. They cover linear, phased-array, and convex probes with plane-wave, diverging-wave, focused, and synthetic-transmit-aperture sequences — representing the diversity of modern ultrasound acquisition strategies.
+
+All data is openly hosted on Zenodo (record 20261898) under the MIT license and stored in the community-standard Ultrasound File Format (UFF/HDF5). We provide a conversion pipeline (pyuff-ustb → zea, and a MATLAB equivalent using h5create/h5write) that maps UFF channel data to the OpenH-RF format, along with DAS reference reconstructions and processing scripts. For simulated and phantom data, true ground truth (scatterer position maps, known phantom geometry) is available.
+
+Our contribution includes 8 in-vivo human datasets (cardiac parasternal/apical views and carotid cross-sections), 4 shear wave elastography and ARFI datasets, and over 40 phantom and simulation datasets covering resolution, contrast, dynamic range, speckle, and point-spread-function evaluation. We confirm intent to release the converted data under CC BY 4.0 as required by OpenH-RF.
+
+---
+
+## Target Task Groups
+
+- [x] 6.1 Generalized Reconstruction
+- [ ] 6.2 Blood Flow Measurements
+- [ ] 6.3 Quantitative Imaging/Measurements
+- [x] 6.4 Motion Estimation (Shear Wave Elastography, ARFI)
+- [ ] 6.5 Ultrasound Interpretation
+- [ ] 6.6 Other Applications
+
+---
+
+## Data Tiers & Estimated Measurements
+
+| Tier | Count | Details |
+|------|-------|---------|
+| In-Vivo Human (research platform) | 8 | 3 cardiac (P2-4), 5 carotid (L7-4) |
+| Phantom / Table-Top | ~25 | CIRS, elastography, dynamic range, point targets |
+| Simulation (Digital) | ~20 | Field II (linear + phased array, various configurations) |
+
+**Total measurements:** 53 channel capture datasets
+
+**Weighted contribution:** ~365 equivalent (8 × 40 + 45 × 1)
+
+---
+
+## Sensor Hardware
+
+- Verasonics Vantage (research ultrasound platform)
+  - P2-4 phased array (64 elements, cardiac)
+  - L7-4 linear array (128 elements, general/vascular)
+- Alpinion E-Cube 12R
+  - L3-8 linear array (128 elements)
+- Field II simulation framework (various virtual probes: P4-1, L7-4)
+
+---
+
+## Estimated Number of Frames
+
+Varies per dataset:
+- Cardiac in-vivo: 10–100+ frames per acquisition
+- Carotid in-vivo: 1–10 frames
+- Phantom: 1 frame (single acquisition)
+- Simulation: 1 frame
+- SWE: multiple push-track frames
+
+**Conservative estimate across all datasets: 500–1000 total frames**
+
+---
+
+## Data Rights & IP Confirmation
+
+We confirm intent to release the contributed dataset under the Creative Commons BY 4.0 licence. All datasets are currently hosted on Zenodo under open-access terms (MIT license on code). No third-party IP encumbrances apply. The PICMUS benchmark datasets were originally distributed by the IEEE IUS community under open terms.
+
+---
+
+## Author List (contributors to be recognized)
+
+1. Ole Marius Hoel Rindal — University of Oslo (lead, USTB developer)
+2. Anders E. Vrålstad — University of Oslo (PhD candidate, blocked array correction)
+3. Alfonso Rodriguez-Molares — NTNU (co-creator of USTB and UFF format)
+4. Andreas Austeng — University of Oslo (Professor, signal processing)
+
+---
+
+## Links
+
+- USTB GitHub: https://github.com/unioslo/USTB
+- USTB website: https://www.ultrasoundtoolbox.com
+- Zenodo dataset record: https://zenodo.org/records/20261898
+- Conversion code: https://github.com/olemarius90/USTB/tree/cursor/openh-rf-proposal-c47b/sandbox/OpenHRF
+
+---
+
+## PDF Upload
+
+Upload: `proposal.pdf` (built from `sandbox/OpenHRF/proposal.tex`)
+
+Build with:
+```bash
+cd sandbox/OpenHRF && pdflatex proposal.tex
+```

--- a/sandbox/OpenHRF/generate_labels.m
+++ b/sandbox/OpenHRF/generate_labels.m
@@ -1,0 +1,99 @@
+%% Generate DAS beamformed labels for all USTB datasets (OpenH-RF contribution)
+%
+% Produces reference B-mode images (DAS, coherent compounding) for each dataset
+% that has channel_data. Output: .mat files with the beamformed envelope.
+%
+% Usage:
+%   addpath(genpath(ustb_path()));
+%   run('sandbox/OpenHRF/generate_labels.m');
+
+clear; close all;
+
+output_dir = fullfile(fileparts(mfilename('fullpath')), 'labels');
+if ~isfolder(output_dir)
+    mkdir(output_dir);
+end
+
+url = tools.zenodo_dataset_files_base();
+local_path = data_path();
+
+datasets = {
+    'Verasonics_P2-4_parasternal_long_small.uff'
+    'L7_CPWC_193328.uff'
+    'L7_FI_IUS2018.uff'
+    'PICMUS_experiment_resolution_distortion.uff'
+    'PICMUS_simulation_resolution_distortion.uff'
+    'PICMUS_experiment_contrast_speckle.uff'
+    'PICMUS_simulation_contrast_speckle.uff'
+    'PICMUS_carotid_cross.uff'
+    'PICMUS_carotid_long.uff'
+    'Alpinion_L3-8_FI_hypoechoic.uff'
+    'Alpinion_L3-8_FI_hyperechoic_scatterers.uff'
+    'Alpinion_L3-8_CPWC_hypoechoic.uff'
+    'Alpinion_L3-8_CPWC_hyperechoic_scatterers.uff'
+    'FieldII_STAI_uniform_fov.uff'
+    'FieldII_CPWC_point_scatterers_res_v2.uff'
+    'L7_CPWC_TheGB.uff'
+    'L7_FI_TheGB.uff'
+    'L7_DW_TheGB.uff'
+    'L7_STA_TheGB.uff'
+    'ARFI_dataset.uff'
+    'SWE_L7_type_I.uff'
+    'P4_FI_121444_45mm_focus.uff'
+    'STAI_UFF_CIRS_phantom.uff'
+    };
+
+fprintf('=== OpenH-RF Label Generation (DAS beamforming) ===\n');
+fprintf('Output: %s\n\n', output_dir);
+
+for k = 1:numel(datasets)
+    fn = datasets{k};
+    fprintf('[%02d/%02d] %s ... ', k, numel(datasets), fn);
+
+    try
+        tools.download(fn, url, local_path);
+        channel_data = uff.read_object(fullfile(local_path, fn), '/channel_data');
+
+        scan = default_scan(channel_data);
+
+        mid = midprocess.das();
+        mid.channel_data = channel_data;
+        mid.scan = scan;
+        mid.dimension = dimension.both();
+        mid.receive_apodization.window = uff.window.hanning;
+        mid.receive_apodization.f_number = 1.75;
+        mid.transmit_apodization.window = uff.window.hanning;
+        mid.transmit_apodization.f_number = 1.75;
+
+        b_data = mid.go();
+
+        envelope = b_data.get_image('none');
+        label_file = fullfile(output_dir, strrep(fn, '.uff', '_label.mat'));
+        save(label_file, 'envelope', 'scan', '-v7.3');
+        fprintf('OK\n');
+    catch ME
+        fprintf('FAILED: %s\n', ME.message);
+    end
+    close all;
+end
+
+fprintf('\nDone.\n');
+
+
+function scan = default_scan(channel_data)
+    if isprop(channel_data.sequence(1).source, 'azimuth') && ...
+            ~isempty(channel_data.sequence(1).source.azimuth) && ...
+            abs(channel_data.sequence(1).source.azimuth) > 0.01
+        az = zeros(channel_data.N_waves, 1);
+        for n = 1:channel_data.N_waves
+            az(n) = channel_data.sequence(n).source.azimuth;
+        end
+        scan = uff.sector_scan('azimuth_axis', az, ...
+            'depth_axis', linspace(0, 110e-3, 512).');
+    else
+        x_range = max(channel_data.probe.x) - min(channel_data.probe.x);
+        scan = uff.linear_scan(...
+            'x_axis', linspace(-x_range/2, x_range/2, 256).', ...
+            'z_axis', linspace(0, 50e-3, 256).');
+    end
+end

--- a/sandbox/OpenHRF/proposal.tex
+++ b/sandbox/OpenHRF/proposal.tex
@@ -1,0 +1,137 @@
+\documentclass[11pt,a4paper]{article}
+\usepackage[margin=2.5cm]{geometry}
+\usepackage{booktabs}
+\usepackage{hyperref}
+\usepackage{enumitem}
+\usepackage{xcolor}
+
+\title{\textbf{OpenH-RF Proposal:}\\[4pt]
+The UltraSound ToolBox (USTB) Channel Capture Dataset}
+\author{
+  Ole Marius Hoel Rindal\textsuperscript{1},
+  Anders E.\ Vr\aa lstad\textsuperscript{1},
+  Alfonso Rodriguez-Molares\textsuperscript{2},\\
+  Andreas Austeng\textsuperscript{1}
+  \\[6pt]
+  \textsuperscript{1}University of Oslo (UiO), Norway \quad
+  \textsuperscript{2}NTNU, Norway
+}
+\date{}
+
+\begin{document}
+\maketitle
+\thispagestyle{empty}
+
+% ------------------------------------------------------------------
+\section{Executive Summary}
+
+We propose to contribute \textbf{53 pre-beamformed (channel capture) ultrasound datasets} from the UltraSound ToolBox (USTB) initiative to OpenH-RF.
+The datasets span \textbf{in-vivo human cardiac and carotid imaging}, \textbf{tissue-mimicking phantoms}, and \textbf{physics-based Field~II simulations}, covering linear, phased-array, and convex probes with plane-wave, diverging-wave, focused, and synthetic-transmit-aperture sequences.
+
+All data is openly hosted on Zenodo (\texttt{10.5281/zenodo.20261898}) under the \textbf{MIT license} and stored in the community-standard Ultrasound File Format (UFF/HDF5).
+We provide a conversion pipeline (\texttt{pyuff-ustb} $\rightarrow$ \texttt{zea}) that maps UFF channel data to the OpenH-RF format, along with DAS reference reconstructions and processing scripts.
+For simulated and phantom data, true ground truth (scatterer maps, known geometry) is available.
+
+The USTB project (\url{https://github.com/unioslo/USTB}, \url{https://www.ultrasoundtoolbox.com}) has been maintained since 2017 and is widely used for ultrasound beamforming research and education.
+All datasets with DAS reference reconstructions are cataloged at \url{https://www.ultrasoundtoolbox.com/datasets.html}.
+
+% ------------------------------------------------------------------
+\section{Task \& Application Selection}
+
+\begin{table}[h!]
+\centering
+\small
+\begin{tabular}{@{}llcrl@{}}
+\toprule
+\textbf{Task Group} & \textbf{Application} & \textbf{Datasets} & \textbf{Tier} & \textbf{Hardware} \\
+\midrule
+\multirow{2}{*}{6.1 Reconstruction}
+  & Echocardiography     & 3 & In-vivo human (x40) & Verasonics P2-4 \\
+  & General (carotid)    & 5 & In-vivo human (x40) & Verasonics L7-4 \\
+  & Phantom benchmarks   & 15 & Phantom (x1) & Verasonics/Alpinion \\
+  & Simulated phantoms   & 18 & Simulation (x1) & Field~II \\
+\midrule
+6.4 Motion Est.
+  & Shear Wave Elast.    & 3 & Phantom (x1) & Verasonics L7-4 \\
+  & ARFI                 & 1 & Phantom (x1) & Verasonics L7-4 \\
+\midrule
+6.1 Reconstruction
+  & Blocked array corr.  & 3 & Simulation (x1) & Field~II P4 \\
+  & Dynamic range eval.  & 5 & Simulation + Phantom (x1) & Field~II / Verasonics \\
+\bottomrule
+\end{tabular}
+\caption{Dataset summary. Total: 53 channel capture measurements.}
+\end{table}
+
+\noindent\textbf{Weighted contribution:}
+8 in-vivo human datasets $\times$ 40 = 320, plus 45 phantom/simulation datasets $\times$ 1 = 45.
+\textbf{Total weighted: $\sim$365 equivalent measurements.}
+
+% ------------------------------------------------------------------
+\section{Technical Approach}
+
+\subsection*{Data Format Conversion}
+Each UFF dataset is converted to OpenH-RF (\texttt{zea} HDF5) using a Python pipeline:
+
+\begin{enumerate}[nosep]
+  \item Read UFF with \texttt{pyuff-ustb} (channel data, probe geometry, transmit sequence).
+  \item Map fields to \texttt{zea} scan dictionary (probe geometry, polar/azimuth angles, focus distances, t0 delays, sampling frequency, sound speed).
+  \item Generate DAS beamformed B-mode image as reference reconstruction using the USTB MATLAB beamformer or the Python \texttt{ustb} package.
+  \item Write \texttt{.hdf5} via \texttt{zea.File.create()}.
+\end{enumerate}
+
+\subsection*{Reference Reconstructions \& Ground Truth}
+We provide DAS beamformed images as \textbf{reference reconstructions} (not ground truth labels) using the USTB beamformer (f-number 1.75, Hanning apodization, coherent compounding).
+True ground truth is available where the scattering medium is known:
+\begin{itemize}[nosep]
+  \item \textbf{Simulations} (Field~II): scatterer position maps and medium definitions.
+  \item \textbf{Phantoms} (CIRS): known cyst/wire geometry, sound speed, attenuation.
+  \item \textbf{SWE/ARFI}: displacement and velocity maps from push-tracking sequences.
+\end{itemize}
+For in-vivo data, no ground truth exists; we supply the raw channel data and processing scripts as permitted by the RFP.
+
+\subsection*{Quality Assurance}
+\begin{itemize}[nosep]
+  \item Automated validation: finite-valued channel data, correct dimensions, non-zero energy.
+  \item Beamformed image sanity checks: peak amplitude, dynamic range $>$ 40\,dB.
+  \item Cross-verified against published results in USTB examples and publications.
+\end{itemize}
+
+% ------------------------------------------------------------------
+\section{Data Rights \& Licensing}
+
+All datasets are released under the \textbf{MIT License} (code) and hosted on Zenodo under open-access terms.
+We confirm intent to release the converted dataset under \textbf{CC~BY~4.0} as required by OpenH-RF.
+No third-party IP encumbrances apply.
+The PICMUS datasets were originally distributed by the IEEE IUS community under open terms for benchmarking.
+
+% ------------------------------------------------------------------
+\section{Team Qualifications}
+
+\begin{itemize}[nosep]
+  \item \textbf{Ole Marius Hoel Rindal} (UiO) --- Lead developer of USTB since 2017; publications on adaptive beamforming, coherence-based imaging, and the Generalized Beamformer.
+  \item \textbf{Anders E.\ Vr\aa lstad} (UiO) --- PhD candidate; retrospective transmit correction of blocked arrays (T-USON 2026).
+  \item \textbf{Alfonso Rodriguez-Molares} (NTNU) --- Co-creator of USTB and the UFF format; generalized contrast-to-noise ratio (gCNR).
+  \item \textbf{Andreas Austeng} (UiO) --- Professor; signal processing for medical ultrasound.
+\end{itemize}
+
+% ------------------------------------------------------------------
+\section{Project Plan}
+
+\begin{table}[h!]
+\centering
+\small
+\begin{tabular}{@{}lll@{}}
+\toprule
+\textbf{Task} & \textbf{Period} & \textbf{Deliverable} \\
+\midrule
+Finalize conversion pipeline & May 18--25, 2026 & \texttt{convert\_ustb\_to\_openh\_rf.py} \\
+Generate reference reconstructions & May 25--Jun 1, 2026 & 53 DAS B-mode images \\
+Convert all datasets to zea HDF5 & Jun 1--7, 2026 & 53 \texttt{.hdf5} files \\
+Quality assurance \& validation & Jun 7--10, 2026 & Validation report \\
+Submit proposal + upload data & Jun 10, 2026 & Proposal + S3/GDrive delivery \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+\end{document}


### PR DESCRIPTION
(51/53 previews in release tarball)

sandbox/OpenHRF/:
- proposal.tex: 2-page LaTeX proposal for OpenH-RF RFP
- convert_ustb_to_openh_rf.py: Python UFF->zea conversion
- convert_ustb_to_openh_rf_matlab.m: MATLAB UFF->zea HDF5 conversion
- generate_labels.m: DAS reference reconstruction script
- form_answers.md: draft Google Form answers

Dataset catalog:
- uff_dataset_registry.m: all 53 Zenodo datasets registered
- dataset_preview_beamform.m: generic fallback + beamformed_only cases
- export_png_like_b_data_plot.m: print() fallback for headless
- export_dataset_previews_to_website.m: beamformed_only mode support
- datasets-html.tar.gz uploaded to examples-v1 release (51 PNGs + HTML)