### PR TITLE
OpenH-RF: USTB channel-capture conversion and submission tooling

### DIFF
--- a/sandbox/OpenHRF/README.md
+++ b/sandbox/OpenHRF/README.md
@@ -1,7 +1,7 @@
 # OpenH-RF Contribution: USTB Datasets
 
-This folder contains the proposal and conversion tools for contributing
-USTB (UltraSound ToolBox) datasets to the
+This folder contains the proposal and conversion/packaging tools for
+contributing USTB (UltraSound ToolBox) datasets to the
 [OpenH-RF](https://github.com/open-h/OpenH-RF) initiative.
 
 ## Contents
@@ -9,40 +9,79 @@ USTB (UltraSound ToolBox) datasets to the
 | File | Description |
 |------|-------------|
 | `proposal.tex` | 2-page LaTeX proposal for the OpenH-RF RFP |
-| `convert_ustb_to_openh_rf.py` | Python script: UFF → zea HDF5 conversion |
-| `generate_labels.m` | MATLAB script: DAS beamforming labels for all datasets |
+| `convert_ustb_to_openh_rf.py` | UFF -> zea HDF5 conversion (spec-compliant `zea.File.create`), grouped A-F |
+| `make_submission.py` | Builds the submission: root `reconstruct.py`/`pipeline.yaml`/`LICENCE` + per-group data cards |
+| `submission_template/` | Canonical `reconstruct.py`, `pipeline.yaml`, `LICENCE` (placed once at the submission root) |
+| `validate_submission.py` | Validates every output `.hdf5` against the zea spec (`File.validate` / `File.validate_spec`) |
+| `write_eval_reports.py` | Runs the `openh-rf-submission-eval` rubric and writes per-group + top-level reports |
+| `export_openhrf_previews.m` | MATLAB: renders the canonical USTB DAS reference B-mode PNGs (catalog-matching) |
+| `convert_ustb_to_openh_rf_matlab.m` | Legacy MATLAB prototype (superseded by the Python converter) |
+| `generate_labels.m` | MATLAB script: DAS beamforming labels |
+
+## PICMUS policy
+
+PICMUS-sourced acquisitions are **excluded** from this submission, with one
+exception: `PICMUS_numerical_calib_v2`. That numerical-calibration acquisition was
+created by the USTB group in a follow-up to the PICMUS effort, so it is retained
+(and documented as such in the group E data card). The excluded PICMUS files are
+the in-vivo carotid (`PICMUS_carotid_cross`, `PICMUS_carotid_long`), the
+experimental resolution/contrast (`PICMUS_experiment_*`), and the simulated
+resolution/contrast (`PICMUS_simulation_*`) acquisitions.
+
+## Submission layout
+
+The submission is packaged as **6 application sub-datasets** (one data card each):
+
+| Group | Folder | Tier | Acquisitions |
+|---|---|---|---|
+| A | `A_cardiac` | in-vivo human | 3 |
+| B | `B_carotid` | in-vivo human | 3 |
+| C | `C_verasonics_phantom` | phantom | 15 |
+| D | `D_alpinion_phantom` | phantom | 4 |
+| E | `E_simulation` | simulation | 12 (incl. 1 PICMUS calibration) |
+| F | `F_motion` | phantom (SWE/ARFI) | 4 |
+
+**Total: 41 eligible channel-capture acquisitions.** Four UFF files referenced in
+the proposal (`reference_RTB_data`, `invitro_20`, `insilico_20`,
+`insilico_side_100_M45`) contain only beamformed data (no raw channel data) and
+are therefore not eligible for OpenH-RF (which requires `/data/raw_data`).
+
+The submission **root** holds a single `reconstruct.py`, `pipeline.yaml` and
+`LICENCE` (CC BY 4.0) that cover the whole collection — `reconstruct.py` is
+geometry-driven and recurses into every group folder. Each **group folder** holds
+its `*.hdf5` (zea), `README.md` (data card), and `*_bmode.png` / `*_zea_bmode.png`
+reference reconstructions.
 
 ## Quick start
 
-### Build the proposal PDF
+The conversion/reconstruction tooling requires `zea` (>= v0.1.0a3; we used v0.1.0)
+and `pyuff-ustb`. We use the OpenH-RF environment (`uv sync` in the OpenH-RF repo)
+which pins `zea`, plus `uv pip install pyuff-ustb`.
 
 ```bash
-cd sandbox/OpenHRF
-pdflatex proposal.tex
-```
+# 1. Convert all UFF datasets to zea HDF5, grouped into A-F
+python convert_ustb_to_openh_rf.py --input C:/Data/USTB_data \
+    --output C:/Data/USTB_data/openh_rf_submission
 
-### Convert datasets
+# 2. Build the root reconstruct.py / pipeline.yaml / LICENCE and per-group data cards
+python make_submission.py --output C:/Data/USTB_data/openh_rf_submission
 
-```bash
-pip install pyuff-ustb zea numpy
-python convert_ustb_to_openh_rf.py --zenodo --output openh_rf/
-```
+# 3. Render reference B-mode PNGs (one root script reconstructs every group folder)
+python C:/Data/USTB_data/openh_rf_submission/reconstruct.py
 
-### Generate labels (MATLAB)
-
-```matlab
-addpath(genpath(ustb_path()));
-run('sandbox/OpenHRF/generate_labels.m');
+# 4. (optional) Validate + self-evaluate the submission
+python validate_submission.py
+python write_eval_reports.py
 ```
 
 ## Dataset source
 
-All 53 datasets are hosted on Zenodo:
+All datasets are hosted on Zenodo:
 - **Record 20261898**: https://zenodo.org/records/20261898
 - **License**: MIT (code), CC BY 4.0 (data contribution to OpenH-RF)
 
 ## Links
 
-- OpenH-RF RFP: https://github.com/open-h/OpenH-RF
+- OpenH-RF: https://github.com/open-h/OpenH-RF
 - USTB: https://github.com/unioslo/USTB
 - USTB website: https://www.ultrasoundtoolbox.com

--- a/sandbox/OpenHRF/convert_ustb_to_openh_rf.py
+++ b/sandbox/OpenHRF/convert_ustb_to_openh_rf.py
@@ -1,15 +1,40 @@
-"""Convert USTB UFF datasets to OpenH-RF (zea) HDF5 format.
+"""Convert USTB UFF datasets to the OpenH-RF (zea) HDF5 format.
 
-Reads .uff files from Zenodo (or local cache) via pyuff-ustb and writes
-.hdf5 files using the zea library in the OpenH-RF data format.
+Reads ``.uff`` files (via ``pyuff-ustb``) and writes spec-compliant ``zea``
+HDF5 files using ``zea.File.create``. The output satisfies the OpenH-RF
+submission requirements: a ``/data/raw_data`` array of shape
+``(n_frames, n_tx, n_ax, n_el, n_ch)``, a fully populated ``/scan`` group
+(``t0_delays``, ``focus_distances``, ``polar_angles``, ``transmit_origins`` …),
+a ``/probe`` group with ``probe_geometry``, and the ``zea_version`` root
+attribute that the OpenH-RF evaluator requires.
 
-Usage:
-    python convert_ustb_to_openh_rf.py --input data/ --output openh_rf/
-    python convert_ustb_to_openh_rf.py --zenodo --output openh_rf/
+The USTB transmit model is geometry-based (each ``uff.wave`` stores a virtual
+source plus a wavefront type). zea instead stores explicit per-element
+``t0_delays`` together with ``focus_distances`` / ``polar_angles`` /
+``transmit_origins`` that select the first/last-arrival wavefront logic. This
+script maps between the two using ``zea``'s own
+``compute_t0_delays_planewave`` / ``compute_t0_delays_focused`` helpers, so the
+delays are guaranteed consistent with zea's beamformer.
 
-Requirements:
+Supported transmit types: coherent plane-wave compounding (CPWC), focused
+imaging (FI), diverging waves (DW) and synthetic transmit aperture (STA).
+
+Datasets are grouped into application sub-datasets (A-F) for OpenH-RF, and the
+PICMUS in-vivo / experiment / simulation acquisitions are excluded
+(``PICMUS_numerical_calib_v2`` is kept, with its PICMUS origin documented in the
+group E data card).
+
+Usage::
+
+    python convert_ustb_to_openh_rf.py --input C:/Data/USTB_data \
+        --output C:/Data/USTB_data/openh_rf_submission
+
+Requirements::
+
     pip install pyuff-ustb zea numpy
 """
+
+from __future__ import annotations
 
 import argparse
 import os
@@ -17,233 +42,431 @@ from pathlib import Path
 
 import numpy as np
 
-ZENODO_RECORD = "20261898"
-ZENODO_BASE = f"https://zenodo.org/records/{ZENODO_RECORD}/files"
+os.environ.setdefault("KERAS_BACKEND", "jax")
 
-DATASETS = [
-    # In-vivo human (cardiac, phased array P2-4)
-    {"filename": "Verasonics_P2-4_parasternal_long_subject_1.uff", "probe": "P2-4", "tier": "in-vivo-human", "anatomy": "heart", "view": "parasternal long"},
-    {"filename": "Verasonics_P2-4_parasternal_long_small.uff", "probe": "P2-4", "tier": "in-vivo-human", "anatomy": "heart", "view": "parasternal long"},
-    {"filename": "Verasonics_P2-4_apical_four_chamber_subject_1.uff", "probe": "P2-4", "tier": "in-vivo-human", "anatomy": "heart", "view": "apical four-chamber"},
-    # In-vivo human (carotid, linear array L7-4)
-    {"filename": "L7_FI_carotid_cross_1.uff", "probe": "L7-4", "tier": "in-vivo-human", "anatomy": "carotid", "view": "cross-section"},
-    {"filename": "L7_FI_carotid_cross_2.uff", "probe": "L7-4", "tier": "in-vivo-human", "anatomy": "carotid", "view": "cross-section"},
-    {"filename": "L7_FI_carotid_cross_sub_2.uff", "probe": "L7-4", "tier": "in-vivo-human", "anatomy": "carotid", "view": "cross-section"},
-    {"filename": "PICMUS_carotid_long.uff", "probe": "L7-4", "tier": "in-vivo-human", "anatomy": "carotid", "view": "longitudinal"},
-    {"filename": "PICMUS_carotid_cross.uff", "probe": "L7-4", "tier": "in-vivo-human", "anatomy": "carotid", "view": "cross-section"},
-    # Phantom (CIRS, tissue-mimicking)
-    {"filename": "PICMUS_experiment_resolution_distortion.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "CIRS phantom", "view": "resolution"},
-    {"filename": "PICMUS_experiment_contrast_speckle.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "CIRS phantom", "view": "contrast"},
-    {"filename": "experimental_STAI_dynamic_range.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "phantom", "view": "dynamic range"},
-    {"filename": "experimental_dynamic_range_phantom.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "phantom", "view": "dynamic range"},
-    {"filename": "STAI_UFF_CIRS_phantom.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "CIRS phantom", "view": "STA"},
-    {"filename": "L7_CPWC_193328.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "phantom", "view": "CPWC"},
-    {"filename": "L7_FI_IUS2018.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "phantom", "view": "focused imaging"},
-    {"filename": "L7_FI_Verasonics.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "phantom", "view": "focused imaging"},
-    {"filename": "L7_FI_Verasonics_CIRS.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "CIRS phantom", "view": "focused imaging"},
-    {"filename": "L7_FI_Verasonics_CIRS_points.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "CIRS phantom", "view": "point targets"},
-    {"filename": "Alpinion_L3-8_FI_hypoechoic.uff", "probe": "L3-8", "tier": "phantom", "anatomy": "phantom", "view": "hypoechoic cyst"},
-    {"filename": "Alpinion_L3-8_FI_hyperechoic_scatterers.uff", "probe": "L3-8", "tier": "phantom", "anatomy": "phantom", "view": "hyperechoic scatterers"},
-    {"filename": "Alpinion_L3-8_CPWC_hypoechoic.uff", "probe": "L3-8", "tier": "phantom", "anatomy": "phantom", "view": "CPWC hypoechoic"},
-    {"filename": "Alpinion_L3-8_CPWC_hyperechoic_scatterers.uff", "probe": "L3-8", "tier": "phantom", "anatomy": "phantom", "view": "CPWC hyperechoic"},
-    {"filename": "ARFI_dataset.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "phantom", "view": "ARFI push"},
-    {"filename": "SWE_L7_type_I.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "elastography phantom", "view": "shear wave"},
-    {"filename": "SWE_L7_type_III.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "elastography phantom", "view": "shear wave"},
-    {"filename": "SWE_L7_type_IV.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "elastography phantom", "view": "shear wave"},
-    {"filename": "reference_RTB_data.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "phantom", "view": "RTB reference"},
-    {"filename": "P4_FI_121444_45mm_focus.uff", "probe": "P4-1", "tier": "phantom", "anatomy": "phantom", "view": "focused phased array"},
-    # Simulation (Field II)
-    {"filename": "PICMUS_simulation_resolution_distortion.uff", "probe": "L7-4", "tier": "simulation", "anatomy": "simulated", "view": "resolution"},
-    {"filename": "PICMUS_simulation_contrast_speckle.uff", "probe": "L7-4", "tier": "simulation", "anatomy": "simulated", "view": "contrast"},
-    {"filename": "PICMUS_numerical_calib_v2.uff", "probe": "L7-4", "tier": "simulation", "anatomy": "simulated", "view": "calibration"},
-    {"filename": "FieldII_CPWC_simulation_v2.uff", "probe": "L7-4", "tier": "simulation", "anatomy": "simulated", "view": "CPWC"},
-    {"filename": "FieldII_CPWC_point_scatterers_res_v2.uff", "probe": "L7-4", "tier": "simulation", "anatomy": "simulated", "view": "point scatterers"},
-    {"filename": "FieldII_STAI_dynamic_range.uff", "probe": "L7-4", "tier": "simulation", "anatomy": "simulated", "view": "dynamic range"},
-    {"filename": "FieldII_STAI_simulated_dynamic_range.uff", "probe": "L7-4", "tier": "simulation", "anatomy": "simulated", "view": "dynamic range"},
-    {"filename": "FieldII_STAI_uniform_fov.uff", "probe": "L7-4", "tier": "simulation", "anatomy": "simulated", "view": "uniform FOV"},
-    {"filename": "FieldII_P4_point_scatterers.uff", "probe": "P4-1", "tier": "simulation", "anatomy": "simulated", "view": "point scatterers"},
-    {"filename": "FI_P4_point_scatterers.uff", "probe": "P4-1", "tier": "simulation", "anatomy": "simulated", "view": "point scatterers"},
-    {"filename": "FI_P4_cysts_center.uff", "probe": "P4-1", "tier": "simulation", "anatomy": "simulated", "view": "cyst"},
-    {"filename": "FieldII_speckle_simulation.uff", "probe": "L7-4", "tier": "simulation", "anatomy": "simulated", "view": "speckle"},
-    {"filename": "FieldII_speckle_DMASsimulation300000pts.uff", "probe": "L7-4", "tier": "simulation", "anatomy": "simulated", "view": "DMAS speckle"},
-    {"filename": "speckle_sim_FI_P4_probe_apod_1_speckle_long_many_angles.uff", "probe": "P4-1", "tier": "simulation", "anatomy": "simulated", "view": "blocked array (full)"},
-    {"filename": "speckle_sim_FI_P4_probe_apod_2_speckle_long_many_angles.uff", "probe": "P4-1", "tier": "simulation", "anatomy": "simulated", "view": "blocked array (1/3)"},
-    {"filename": "speckle_sim_FI_P4_probe_apod_3_speckle_long_many_angles.uff", "probe": "P4-1", "tier": "simulation", "anatomy": "simulated", "view": "blocked array (1/2)"},
-    # Generalized Beamformer datasets
-    {"filename": "L7_CPWC_TheGB.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "phantom", "view": "CPWC"},
-    {"filename": "L7_FI_TheGB.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "phantom", "view": "focused imaging"},
-    {"filename": "L7_DW_TheGB.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "phantom", "view": "diverging wave"},
-    {"filename": "L7_STA_TheGB.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "phantom", "view": "synthetic transmit aperture"},
-    # Large in-vivo
-    {"filename": "invitro_20.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "tissue phantom", "view": "in-vitro"},
-    {"filename": "insilico_20.uff", "probe": "L7-4", "tier": "simulation", "anatomy": "simulated", "view": "in-silico"},
-    {"filename": "insilico_side_100_M45.uff", "probe": "L7-4", "tier": "simulation", "anatomy": "simulated", "view": "in-silico side"},
-    {"filename": "beamformed_simulated_data.uff", "probe": "L7-4", "tier": "simulation", "anatomy": "simulated", "view": "DRA beamformed"},
-    {"filename": "beamformed_experimental_data.uff", "probe": "L7-4", "tier": "phantom", "anatomy": "phantom", "view": "DRA beamformed"},
-]
+# ---------------------------------------------------------------------------
+# Dataset registry: group -> list of (filename, probe, probe_type, view, notes)
+# Groups map to OpenH-RF application sub-datasets A-F.
+# The six excluded PICMUS files are simply absent from this list.
+# ---------------------------------------------------------------------------
+GROUPS: dict[str, dict] = {
+    "A_cardiac": {
+        "pretty": "In-vivo cardiac (Verasonics P4-2)",
+        "tier": "in-vivo-human",
+        "datasets": [
+            {"filename": "Verasonics_P2-4_parasternal_long_subject_1.uff", "probe": "P4-2", "probe_type": "phased", "view": "parasternal long-axis"},
+            {"filename": "Verasonics_P2-4_parasternal_long_small.uff", "probe": "P4-2", "probe_type": "phased", "view": "parasternal long-axis"},
+            {"filename": "Verasonics_P2-4_apical_four_chamber_subject_1.uff", "probe": "P4-2", "probe_type": "phased", "view": "apical four-chamber"},
+        ],
+    },
+    "B_carotid": {
+        "pretty": "In-vivo carotid (Verasonics L7-4)",
+        "tier": "in-vivo-human",
+        "datasets": [
+            {"filename": "L7_FI_carotid_cross_1.uff", "probe": "L7-4", "probe_type": "linear", "view": "carotid cross-section"},
+            {"filename": "L7_FI_carotid_cross_2.uff", "probe": "L7-4", "probe_type": "linear", "view": "carotid cross-section"},
+            {"filename": "L7_FI_carotid_cross_sub_2.uff", "probe": "L7-4", "probe_type": "linear", "view": "carotid cross-section"},
+        ],
+    },
+    "C_verasonics_phantom": {
+        "pretty": "Phantom (Verasonics L7-4 / P4)",
+        "tier": "phantom",
+        "datasets": [
+            {"filename": "experimental_STAI_dynamic_range.uff", "probe": "L7-4", "probe_type": "linear", "view": "STA dynamic range phantom"},
+            {"filename": "experimental_dynamic_range_phantom.uff", "probe": "L7-4", "probe_type": "linear", "view": "dynamic range phantom"},
+            {"filename": "STAI_UFF_CIRS_phantom.uff", "probe": "L7-4", "probe_type": "linear", "view": "CIRS phantom (STA)"},
+            {"filename": "L7_CPWC_193328.uff", "probe": "L7-4", "probe_type": "linear", "view": "CPWC phantom"},
+            {"filename": "L7_FI_IUS2018.uff", "probe": "L7-4", "probe_type": "linear", "view": "focused phantom"},
+            {"filename": "L7_FI_Verasonics.uff", "probe": "L7-4", "probe_type": "linear", "view": "focused phantom"},
+            {"filename": "L7_FI_Verasonics_CIRS.uff", "probe": "L7-4", "probe_type": "linear", "view": "CIRS phantom (focused)"},
+            {"filename": "L7_FI_Verasonics_CIRS_points.uff", "probe": "L7-4", "probe_type": "linear", "view": "CIRS point targets"},
+            {"filename": "P4_FI_121444_45mm_focus.uff", "probe": "P4-1", "probe_type": "phased", "view": "focused phased-array phantom"},
+            {"filename": "FI_P4_point_scatterers.uff", "probe": "P4-2", "probe_type": "phased", "view": "Verasonics P4-2 focused point scatterers"},
+            {"filename": "FI_P4_cysts_center.uff", "probe": "P4-2", "probe_type": "phased", "view": "Verasonics P4-2 focused cyst phantom"},
+            {"filename": "L7_CPWC_TheGB.uff", "probe": "L7-4", "probe_type": "linear", "view": "CPWC (Generalized Beamformer)"},
+            {"filename": "L7_FI_TheGB.uff", "probe": "L7-4", "probe_type": "linear", "view": "focused (Generalized Beamformer)"},
+            {"filename": "L7_DW_TheGB.uff", "probe": "L7-4", "probe_type": "linear", "view": "diverging wave (Generalized Beamformer)"},
+            {"filename": "L7_STA_TheGB.uff", "probe": "L7-4", "probe_type": "linear", "view": "synthetic transmit aperture (Generalized Beamformer)"},
+            # Note: reference_RTB_data.uff and invitro_20.uff are beamformed-only (no raw
+            # channel data) and are therefore not eligible for OpenH-RF.
+        ],
+    },
+    "D_alpinion_phantom": {
+        "pretty": "Phantom (Alpinion L3-8)",
+        "tier": "phantom",
+        "datasets": [
+            {"filename": "Alpinion_L3-8_FI_hypoechoic.uff", "probe": "L3-8", "probe_type": "linear", "view": "focused hypoechoic cyst"},
+            {"filename": "Alpinion_L3-8_FI_hyperechoic_scatterers.uff", "probe": "L3-8", "probe_type": "linear", "view": "focused hyperechoic scatterers"},
+            {"filename": "Alpinion_L3-8_CPWC_hypoechoic.uff", "probe": "L3-8", "probe_type": "linear", "view": "CPWC hypoechoic cyst"},
+            {"filename": "Alpinion_L3-8_CPWC_hyperechoic_scatterers.uff", "probe": "L3-8", "probe_type": "linear", "view": "CPWC hyperechoic scatterers"},
+        ],
+    },
+    "E_simulation": {
+        "pretty": "Simulation (Field II)",
+        "tier": "simulation",
+        "datasets": [
+            {"filename": "FieldII_CPWC_simulation_v2.uff", "probe": "L7-4", "probe_type": "linear", "view": "CPWC simulation"},
+            {"filename": "FieldII_CPWC_point_scatterers_res_v2.uff", "probe": "L7-4", "probe_type": "linear", "view": "CPWC point scatterers"},
+            {"filename": "FieldII_STAI_dynamic_range.uff", "probe": "L7-4", "probe_type": "linear", "view": "STA dynamic range"},
+            {"filename": "FieldII_STAI_simulated_dynamic_range.uff", "probe": "L7-4", "probe_type": "linear", "view": "STA dynamic range"},
+            # Website preview uses /channel_data_speckle; /channel_data is the string-grid target.
+            {"filename": "FieldII_STAI_uniform_fov.uff", "probe": "L7-4", "probe_type": "linear", "view": "STA uniform FOV (speckle)", "uff_path": "channel_data_speckle"},
+            {"filename": "FieldII_P4_point_scatterers.uff", "probe": "P4-1", "probe_type": "phased", "view": "phased-array point scatterers"},
+            {"filename": "FieldII_speckle_simulation.uff", "probe": "L7-4", "probe_type": "linear", "view": "speckle"},
+            {"filename": "FieldII_speckle_DMASsimulation300000pts.uff", "probe": "L7-4", "probe_type": "linear", "view": "dense speckle"},
+            {"filename": "speckle_sim_FI_P4_probe_apod_1_speckle_long_many_angles.uff", "probe": "P4-1", "probe_type": "phased", "view": "blocked array (full aperture)"},
+            {"filename": "speckle_sim_FI_P4_probe_apod_2_speckle_long_many_angles.uff", "probe": "P4-1", "probe_type": "phased", "view": "blocked array (1/3 aperture)"},
+            {"filename": "speckle_sim_FI_P4_probe_apod_3_speckle_long_many_angles.uff", "probe": "P4-1", "probe_type": "phased", "view": "blocked array (1/2 aperture)"},
+            # Note: insilico_20.uff and insilico_side_100_M45.uff are beamformed-only (no raw
+            # channel data) and are therefore not eligible for OpenH-RF.
+            # Kept PICMUS file: numerical calibration only. PICMUS origin documented in data card.
+            {"filename": "PICMUS_numerical_calib_v2.uff", "probe": "L7-4", "probe_type": "linear", "view": "numerical calibration (PICMUS-derived)", "picmus_origin": True},
+        ],
+    },
+    "F_motion": {
+        "pretty": "Motion estimation (SWE / ARFI, Verasonics L7-4)",
+        "tier": "phantom",
+        "datasets": [
+            {"filename": "ARFI_dataset.uff", "probe": "L7-4", "probe_type": "linear", "view": "ARFI push-track"},
+            {"filename": "SWE_L7_type_I.uff", "probe": "L7-4", "probe_type": "linear", "view": "shear wave elastography (type I)"},
+            {"filename": "SWE_L7_type_III.uff", "probe": "L7-4", "probe_type": "linear", "view": "shear wave elastography (type III)"},
+            {"filename": "SWE_L7_type_IV.uff", "probe": "L7-4", "probe_type": "linear", "view": "shear wave elastography (type IV)"},
+        ],
+    },
+}
+
+# STA detection: a focused/diverging virtual source whose |z| is below this
+# threshold is treated as a single-element synthetic-aperture transmit.
+STA_Z_THRESHOLD_M = 1.0e-3
 
 
-def download_if_missing(filename: str, data_dir: Path) -> Path:
-    """Download .uff from Zenodo if not cached locally."""
-    import urllib.request
-
-    filepath = data_dir / filename
-    if filepath.exists():
-        return filepath
-    data_dir.mkdir(parents=True, exist_ok=True)
-    url = f"{ZENODO_BASE}/{filename}"
-    print(f"Downloading {url} ...")
-    urllib.request.urlretrieve(url, filepath)
-    return filepath
-
-
-def read_uff_channel_data(filepath: Path):
-    """Read channel_data from a UFF file using pyuff-ustb."""
+def _read_channel_data(filepath: Path, uff_path: str = "channel_data"):
     from pyuff_ustb.objects.uff import Uff
 
-    uff_file = Uff(str(filepath))
+    uff = Uff(str(filepath))
     try:
-        return uff_file.read("channel_data")
-    except Exception:
+        return uff.read(uff_path)
+    except Exception as exc:  # noqa: BLE001
+        print(f"    no {uff_path} ({exc})")
         return None
 
 
-def uff_to_zea_scan(channel_data) -> dict:
-    """Map pyuff-ustb ChannelData to a zea-compatible scan dictionary."""
-    probe = channel_data.probe
-    sequence = channel_data.sequence
-
+def _probe_geometry(probe) -> np.ndarray:
     n_el = int(probe.N_elements)
-    probe_geometry = np.zeros((n_el, 3), dtype=np.float32)
-    probe_geometry[:, 0] = np.array(probe.x, dtype=np.float32).flatten()
-    if hasattr(probe, 'y') and probe.y is not None:
-        probe_geometry[:, 1] = np.array(probe.y, dtype=np.float32).flatten()
-    if hasattr(probe, 'z') and probe.z is not None:
-        probe_geometry[:, 2] = np.array(probe.z, dtype=np.float32).flatten()
+    geom = np.zeros((n_el, 3), dtype=np.float32)
+    geom[:, 0] = np.asarray(probe.x, dtype=np.float32).ravel()
+    if probe.y is not None:
+        geom[:, 1] = np.asarray(probe.y, dtype=np.float32).ravel()
+    if probe.z is not None:
+        geom[:, 2] = np.asarray(probe.z, dtype=np.float32).ravel()
+    return geom
 
+
+def _build_transmit_fields(channel_data, probe_geometry: np.ndarray, sound_speed: float):
+    """Map the USTB wave sequence onto zea transmit fields.
+
+    Returns a dict with ``t0_delays`` ``(n_tx, n_el)``, ``tx_apodizations``
+    ``(n_tx, n_el)``, ``focus_distances`` ``(n_tx,)``, ``polar_angles``
+    ``(n_tx,)``, ``azimuth_angles`` ``(n_tx,)``, ``transmit_origins``
+    ``(n_tx, 3)`` and ``wave_delays`` ``(n_tx,)``.
+    """
+    from zea.beamform.beamformer import transmit_delays
+    from zea.beamform.delays import (
+        compute_t0_delays_focused,
+        compute_t0_delays_planewave,
+    )
+
+    sequence = channel_data.sequence
+    if not isinstance(sequence, (list, tuple)):
+        sequence = [sequence]
     n_tx = len(sequence)
-    sampling_frequency = float(channel_data.sampling_frequency)
-    sound_speed = float(channel_data.sound_speed)
+    n_el = probe_geometry.shape[0]
 
+    t0_delays = np.zeros((n_tx, n_el), dtype=np.float32)
+    tx_apod = np.ones((n_tx, n_el), dtype=np.float32)
+    focus_distances = np.zeros(n_tx, dtype=np.float32)
     polar_angles = np.zeros(n_tx, dtype=np.float32)
     azimuth_angles = np.zeros(n_tx, dtype=np.float32)
-    focus_distances = np.full(n_tx, np.inf, dtype=np.float32)
-    initial_times = np.zeros(n_tx, dtype=np.float32)
+    transmit_origins = np.zeros((n_tx, 3), dtype=np.float32)
+    wave_delays = np.zeros(n_tx, dtype=np.float32)
+    # Per-wave correction added to initial_times (seconds). For synthetic
+    # transmit aperture (single-element transmits), every transmit is recorded
+    # with the same A/D start, so initial_times must be a constant across
+    # transmits; any per-transmit variation breaks the coherent synthetic-aperture
+    # focusing and smears the image laterally. The STA branch therefore cancels
+    # the per-wave wave.delay term so that initial_times = channel_data.initial_time
+    # (verified against the USTB preview: constant -> sharp, variable -> blurred).
+    init_correction = np.zeros(n_tx, dtype=np.float32)
+    is_sta = np.zeros(n_tx, dtype=bool)
+    source_distances = np.zeros(n_tx, dtype=np.float32)  # |element| for STA transmits
 
     for i, wave in enumerate(sequence):
+        wave_delays[i] = float(wave.delay) if wave.delay is not None else 0.0
         src = wave.source
-        if hasattr(src, 'azimuth') and src.azimuth is not None:
-            polar_angles[i] = float(src.azimuth)
-        if hasattr(src, 'elevation') and src.elevation is not None:
-            azimuth_angles[i] = float(src.elevation)
-        if hasattr(src, 'distance') and src.distance is not None:
-            focus_distances[i] = float(src.distance)
-        if hasattr(wave, 'delay') and wave.delay is not None:
-            initial_times[i] = float(wave.delay)
+        sx, sy, sz = float(src.x), float(src.y), float(src.z)
+        az = float(src.azimuth)
+        el = float(src.elevation)
+        dist = float(src.distance)
 
-    center_frequency = 0.0
-    if hasattr(channel_data, 'pulse') and channel_data.pulse is not None:
-        if hasattr(channel_data.pulse, 'center_frequency'):
-            center_frequency = float(channel_data.pulse.center_frequency or 0)
+        plane_wave = (not np.isfinite(sz)) or (not np.isfinite(dist)) or (not np.isfinite(sx))
 
-    scan = {
-        "probe_geometry": probe_geometry,
-        "sampling_frequency": sampling_frequency,
-        "center_frequency": center_frequency,
-        "initial_times": initial_times,
-        "t0_delays": np.zeros((n_tx, n_el), dtype=np.float32),
-        "tx_apodizations": np.ones((n_tx, n_el), dtype=np.float32),
+        if plane_wave:
+            # Plane wave: USTB azimuth/elevation are the steering angles, which
+            # map directly to zea polar/azimuth (v = sin(p)cos(a), sin(p)sin(a), cos(p)).
+            polar_angles[i] = az
+            azimuth_angles[i] = el
+            focus_distances[i] = 0.0  # plane wave
+            transmit_origins[i] = (0.0, 0.0, 0.0)
+            t0_delays[i] = compute_t0_delays_planewave(
+                probe_geometry, np.array([az]), np.array([el]), sound_speed
+            )[0]
+            continue
+
+        if abs(sz) < STA_Z_THRESHOLD_M:
+            # Synthetic transmit aperture: virtual source sits on the array
+            # surface -> single-element transmit. The active element fires at
+            # t=0 and all other elements are masked via tx_apodization=0.
+            active = int(np.argmin(np.linalg.norm(probe_geometry - np.array([sx, sy, sz]), axis=1)))
+            t0_delays[i] = 0.0
+            tx_apod[i] = 0.0
+            tx_apod[i, active] = 1.0
+            focus_distances[i] = 0.0
+            polar_angles[i] = 0.0
+            transmit_origins[i] = probe_geometry[active]
+            is_sta[i] = True
+            source_distances[i] = float(np.linalg.norm(probe_geometry[active]))
+            # fd=0 is interpreted as plane-wave in zea; use a short virtual source below
+            # the element so spherical STA propagation is used.
+            focus_distances[i] = -1e-3
+            polar_angles[i] = np.pi / 2
+            continue
+
+        # Focused (sz > 0) or diverging (sz < 0) wave with a finite virtual source.
+        source = np.array([sx, sy, sz], dtype=np.float64)
+        norm = float(np.linalg.norm(source))
+        fd_signed = np.sign(sz) * norm
+        v = source / fd_signed  # so that origin(0) + fd_signed * v == source
+        # Signed in-plane (x-z) steering angle so that left/right beams of a
+        # sector scan map to negative/positive polar angles (zea v = (sin p cos a,
+        # sin p sin a, cos p); imaging is in the x-z plane so azimuth ~ 0).
+        polar = float(np.arctan2(v[0], v[2]))
+        azimuth = float(np.arctan2(v[1], np.hypot(v[0], v[2])))
+
+        focus_distances[i] = fd_signed
+        polar_angles[i] = polar
+        azimuth_angles[i] = azimuth
+        transmit_origins[i] = (0.0, 0.0, 0.0)
+        t0_delays[i] = compute_t0_delays_focused(
+            np.zeros((1, 3)),
+            np.array([fd_signed]),
+            probe_geometry,
+            np.array([polar]),
+            np.array([azimuth]),
+            sound_speed,
+        )[0]
+
+    # Per-wave time reference (C_wave): zea's t0-based helpers shift each transmit
+    # so its first element fires at t=0, putting every transmit on a *different*
+    # time reference. USTB references every transmit to the array origin (its
+    # transmit delay is 0 at the origin for plane, diverging and focused waves),
+    # so to compound/scan-convert coherently we add zea's transmit arrival at the
+    # origin to initial_times. (STA is handled separately above.)
+    origin = np.zeros((1, 3), dtype=np.float32)
+    rxdel0 = (np.linalg.norm(origin[:, None, :] - probe_geometry[None, :, :], axis=-1)
+              / sound_speed).astype(np.float32)  # (1, n_el)
+    for i in range(n_tx):
+        if is_sta[i]:
+            continue
+        arrival = transmit_delays(
+            origin, t0_delays[i], tx_apod[i], rxdel0, float(focus_distances[i]),
+            float(polar_angles[i]), 0.0, float(azimuth_angles[i]), transmit_origins[i],
+        )
+        init_correction[i] = float(np.array(arrival)[0])
+
+    # STA initial_times. For Field II STA simulations each transmit's signal starts at
+    # its own Field II time t(n), encoded in wave.delay = source.distance/c - lag*dt + t(n).
+    # zea reads sample (|elem - pixel|/c + |rx - pixel|/c - initial_times) * fs, so to place
+    # every single-element transmit at the correct depth the per-transmit offset must be
+    #     initial_times = channel.initial_time + wave.delay - source.distance/c.
+    # (Empirically verified against the stored USTB /b_data_das: the - source.distance/c
+    # term is what aligns the transmits in depth; +source.distance/c or 0 leave it defocused.)
+    #
+    # The Verasonics / experimental STA import stores a pre-compensated wave.delay (signed
+    # across the aperture) referenced to a common A/D start and is already correct with a
+    # constant initial_times; those datasets are verified good and are left untouched
+    # (cancel wave.delay -> initial_times = channel.initial_time).
+    sta_idx = np.flatnonzero(is_sta)
+    if sta_idx.size:
+        wd_sta = wave_delays[sta_idx]
+        if np.all(wd_sta >= 0):  # Field II geometric wave.delay
+            init_correction[sta_idx] = -source_distances[sta_idx] / sound_speed
+        else:  # Verasonics / experimental: pre-compensated, keep constant initial_times
+            init_correction[sta_idx] = -wave_delays[sta_idx]
+
+    return {
+        "t0_delays": t0_delays,
+        "tx_apodizations": tx_apod,
         "focus_distances": focus_distances,
-        "transmit_origins": np.zeros((n_tx, 3), dtype=np.float32),
         "polar_angles": polar_angles,
         "azimuth_angles": azimuth_angles,
-        "sound_speed": sound_speed,
+        "transmit_origins": transmit_origins,
+        "wave_delays": wave_delays,
+        "init_correction": init_correction,
     }
-    return scan
 
 
-def convert_dataset(filepath: Path, output_dir: Path, meta: dict) -> bool:
-    """Convert a single UFF file to OpenH-RF zea HDF5."""
-    from zea import File
-
-    channel_data = read_uff_channel_data(filepath)
-    if channel_data is None:
-        print(f"  SKIP (no channel_data): {filepath.name}")
-        return False
-
-    raw = np.array(channel_data.data, dtype=np.float32)
-    # UFF shape: [samples, channels, waves, frames] -> [frames, tx, samples, elements, 1]
-    if raw.ndim == 4:
-        raw = raw.transpose(3, 2, 0, 1)  # [frames, waves, samples, channels]
-    elif raw.ndim == 3:
-        raw = raw.transpose(2, 0, 1)  # [waves, samples, channels]
-        raw = raw[np.newaxis, ...]  # [1, waves, samples, channels]
+def _reshape_raw(data: np.ndarray):
+    """USTB (n_ax, n_el[, n_tx[, n_frames]]) -> zea (n_frames, n_tx, n_ax, n_el, n_ch)."""
+    data = np.asarray(data)
+    while data.ndim < 4:
+        data = data[..., np.newaxis]  # pad trailing wave/frame dims
+    # now (n_ax, n_el, n_tx, n_frames)
+    data = np.transpose(data, (3, 2, 0, 1))  # (n_frames, n_tx, n_ax, n_el)
+    if np.iscomplexobj(data):
+        raw = np.stack([data.real, data.imag], axis=-1).astype(np.float32)  # n_ch=2 (IQ)
+        is_iq = True
     else:
-        print(f"  SKIP (unexpected shape {raw.shape}): {filepath.name}")
-        return False
+        raw = data[..., np.newaxis].astype(np.float32)  # n_ch=1 (RF)
+        is_iq = False
+    return raw, is_iq
 
-    raw = raw[..., np.newaxis]  # add trailing dim -> [frames, tx, samples, el, 1]
 
-    scan = uff_to_zea_scan(channel_data)
-    output_path = output_dir / filepath.with_suffix(".hdf5").name
+def uff_to_zea(channel_data, meta: dict):
+    """Build (data, scan, probe, metadata) dicts for ``zea.File.create``."""
+    sound_speed = float(channel_data.sound_speed)
+    probe_geometry = _probe_geometry(channel_data.probe)
+
+    raw, is_iq = _reshape_raw(channel_data.data)
+
+    center_frequency = 0.0
+    if getattr(channel_data, "pulse", None) is not None and channel_data.pulse.center_frequency is not None:
+        center_frequency = float(channel_data.pulse.center_frequency)
+    modulation_frequency = float(channel_data.modulation_frequency or 0.0)
+    if center_frequency <= 0:
+        center_frequency = modulation_frequency
+
+    tx = _build_transmit_fields(channel_data, probe_geometry, sound_speed)
+    n_tx = tx["t0_delays"].shape[0]
+
+    initial_time = float(channel_data.initial_time or 0.0)
+    # USTB computes the data sample for a pixel as
+    #   (rx_tof + tx_tof/c - wave_delay - initial_time) * fs
+    # while zea uses (rx_tof + tx_arrival - initial_times) * fs with the same
+    # geometry. Matching the two gives initial_times = initial_time + wave_delay
+    # (+ a per-wave correction for the STA single-element model, see init_correction).
+    initial_times = (initial_time + tx["wave_delays"] + tx["init_correction"]).astype(np.float32)
+
+    if is_iq:
+        demodulation_frequency = modulation_frequency if modulation_frequency > 0 else center_frequency
+    else:
+        demodulation_frequency = center_frequency  # demodulate RF in the pipeline
+
+    scan = {
+        "sampling_frequency": np.float32(channel_data.sampling_frequency),
+        "center_frequency": np.float32(center_frequency),
+        "demodulation_frequency": np.float32(demodulation_frequency),
+        "sound_speed": np.float32(sound_speed),
+        "initial_times": initial_times,
+        "t0_delays": tx["t0_delays"],
+        "tx_apodizations": tx["tx_apodizations"],
+        "focus_distances": tx["focus_distances"],
+        "transmit_origins": tx["transmit_origins"],
+        "polar_angles": tx["polar_angles"],
+        "azimuth_angles": tx["azimuth_angles"],
+    }
+
+    probe = {
+        "name": meta["probe"],
+        "type": meta["probe_type"],
+        "probe_geometry": probe_geometry,
+        "probe_center_frequency": np.float32(center_frequency),
+    }
+    pr = channel_data.probe
+    if getattr(pr, "element_width", None) is not None:
+        probe["element_width"] = np.float32(pr.element_width)
+    if getattr(pr, "element_height", None) is not None:
+        probe["element_height"] = np.float32(pr.element_height)
 
     metadata = {
-        "annotations": {
-            "anatomy": meta.get("anatomy", ""),
-            "view": meta.get("view", ""),
-        },
-        "credit": "USTB - UltraSound ToolBox (University of Oslo)",
-        "subject": {"type": meta.get("tier", "unknown")},
+        "credit": "UltraSound ToolBox (USTB), University of Oslo. Zenodo record 20261898.",
+        "subject": {"type": "human" if meta["tier"] == "in-vivo-human" else meta["tier"]},
+        "annotations": {"view": meta["view"]},
     }
 
+    data = {"raw_data": raw}
+    return data, scan, probe, metadata, {"n_tx": n_tx, "is_iq": is_iq, "shape": raw.shape}
+
+
+def convert_one(filepath: Path, out_path: Path, meta: dict) -> bool:
+    from zea import File
+
+    uff_path = meta.get("uff_path", "channel_data")
+    channel_data = _read_channel_data(filepath, uff_path)
+    if channel_data is None:
+        print(f"  SKIP (no {uff_path}): {filepath.name}")
+        return False
+
+    data, scan, probe, metadata, info = uff_to_zea(channel_data, meta)
+    description = f"USTB dataset {filepath.stem}: {meta['view']} ({meta['tier']})."
+    if uff_path != "channel_data":
+        description += f" Converted from UFF /{uff_path} (original file also contains /channel_data)."
+
     File.create(
-        path=str(output_path),
-        data={"raw_data": raw},
+        path=str(out_path),
+        data=data,
         scan=scan,
+        probe=probe,
         metadata=metadata,
-        probe_name=meta.get("probe", "unknown"),
-        us_machine="Verasonics / Alpinion / Field II simulation",
-        description=f"USTB dataset: {filepath.stem}. {meta.get('view', '')}. "
-                    f"Tier: {meta.get('tier', '')}.",
+        us_machine="Verasonics Vantage 256 / Alpinion E-Cube 12R / Field II simulation",
+        description=description,
+        overwrite=True,
     )
-    print(f"  OK: {output_path.name} ({raw.shape})")
+    print(f"  OK: {out_path.name}  raw={info['shape']}  {'IQ' if info['is_iq'] else 'RF'}  n_tx={info['n_tx']}")
     return True
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Convert USTB UFF to OpenH-RF")
-    parser.add_argument("--input", type=str, default="data",
-                        help="Directory with local .uff files")
-    parser.add_argument("--output", type=str, default="openh_rf",
-                        help="Output directory for .hdf5 files")
-    parser.add_argument("--zenodo", action="store_true",
-                        help="Download from Zenodo if file not in --input")
-    parser.add_argument("--limit", type=int, default=0,
-                        help="Limit number of datasets to convert (0=all)")
+    parser = argparse.ArgumentParser(description="Convert USTB UFF to OpenH-RF zea HDF5")
+    parser.add_argument("--input", type=str, default=r"C:\Data\USTB_data", help="Directory with .uff files")
+    parser.add_argument("--output", type=str, default=r"C:\Data\USTB_data\openh_rf_submission", help="Output staging directory")
+    parser.add_argument("--groups", type=str, default="", help="Comma-separated subset of groups to convert (default: all)")
+    parser.add_argument("--only", type=str, default="", help="Convert only the given filename (debug)")
     args = parser.parse_args()
 
-    data_dir = Path(args.input)
-    output_dir = Path(args.output)
-    output_dir.mkdir(parents=True, exist_ok=True)
+    in_dir = Path(args.input)
+    out_root = Path(args.output)
+    out_root.mkdir(parents=True, exist_ok=True)
 
-    datasets = DATASETS[:args.limit] if args.limit > 0 else DATASETS
-    ok_count = 0
+    selected = set(args.groups.split(",")) if args.groups else set(GROUPS)
+    ok = miss = fail = 0
 
-    for meta in datasets:
-        fn = meta["filename"]
-        filepath = data_dir / fn
-        if not filepath.exists() and args.zenodo:
-            filepath = download_if_missing(fn, data_dir)
-        if not filepath.exists():
-            print(f"  MISSING: {fn}")
+    for group, ginfo in GROUPS.items():
+        if group not in selected:
             continue
-        try:
-            if convert_dataset(filepath, output_dir, meta):
-                ok_count += 1
-        except Exception as e:
-            print(f"  ERROR ({fn}): {e}")
+        gdir = out_root / group
+        gdir.mkdir(parents=True, exist_ok=True)
+        print(f"\n=== {group}: {ginfo['pretty']} ===")
+        for meta in ginfo["datasets"]:
+            fn = meta["filename"]
+            if args.only and fn != args.only:
+                continue
+            src = in_dir / fn
+            if not src.exists():
+                print(f"  MISSING: {fn}")
+                miss += 1
+                continue
+            out_path = gdir / (Path(fn).stem + ".hdf5")
+            meta_full = {**meta, "tier": ginfo["tier"]}
+            try:
+                if convert_one(src, out_path, meta_full):
+                    ok += 1
+                else:
+                    fail += 1
+            except Exception as exc:  # noqa: BLE001
+                print(f"  ERROR ({fn}): {type(exc).__name__}: {exc}")
+                fail += 1
 
-    print(f"\nConverted {ok_count}/{len(datasets)} datasets to {output_dir}/")
+    print(f"\n=== Done: {ok} converted, {miss} missing, {fail} failed ===")
 
 
 if __name__ == "__main__":

--- a/sandbox/OpenHRF/export_openhrf_previews.m
+++ b/sandbox/OpenHRF/export_openhrf_previews.m
@@ -1,0 +1,101 @@
+function export_openhrf_previews(only_stem, only_group)
+%EXPORT_OPENHRF_PREVIEWS  Render submission reference PNGs with the canonical
+%   USTB DAS beamforming used for the public dataset catalog (website).
+%
+%   For every <stem>.hdf5 in each OpenH-RF submission group folder, this reads
+%   the original <stem>.uff from data_dir, beamforms it with
+%   examples/dataset_catalog_previews/dataset_preview_beamform.m (the exact
+%   per-dataset reconstruction used on https://unioslo.github.io/USTB/datasets.html),
+%   and writes <stem>_bmode.png with the title "USTB: <dataset>".
+%
+%   Usage (headless):
+%     matlab -batch "export_openhrf_previews()"                           % all
+%     matlab -batch "export_openhrf_previews('L7_FI_carotid_cross_1')"    % one dataset
+%     matlab -batch "export_openhrf_previews('', 'C_verasonics_phantom')" % one group
+
+if nargin < 1
+    only_stem = '';
+end
+if nargin < 2
+    only_group = '';
+end
+
+this = fileparts(mfilename('fullpath'));        % sandbox/OpenHRF
+repo = fileparts(fileparts(this));              % repo root
+addpath(repo);
+addpath(fullfile(repo, 'examples', 'dataset_catalog_previews'));
+addpath(fullfile(repo, 'examples', 'dataset_smoke_tests'));
+
+data_dir = 'C:\Data\USTB_data';
+sub_root = fullfile(data_dir, 'openh_rf_submission');
+
+groups = dir(sub_root);
+groups = groups([groups.isdir] & ~startsWith({groups.name}, '.'));
+
+n_ok = 0; n_fail = 0;
+for gi = 1:numel(groups)
+    if ~isempty(only_group) && ~strcmp(groups(gi).name, only_group)
+        continue
+    end
+    gdir = fullfile(sub_root, groups(gi).name);
+    hd = dir(fullfile(gdir, '*.hdf5'));
+    for hi = 1:numel(hd)
+        stem = erase(hd(hi).name, '.hdf5');
+        if ~isempty(only_stem) && ~strcmp(stem, only_stem)
+            continue
+        end
+        uff_file = fullfile(data_dir, [stem '.uff']);
+        png_path = fullfile(gdir, [stem '_bmode.png']);
+        if ~isfile(uff_file)
+            fprintf('[MISS] %s (no .uff)\n', stem);
+            n_fail = n_fail + 1;
+            continue
+        end
+        try
+            b_data = dataset_preview_beamform(uff_file);
+            export_bmode_png_headless(b_data, png_path, 60, stem);
+            fprintf('[ OK ] %s/%s_bmode.png\n', groups(gi).name, stem);
+            n_ok = n_ok + 1;
+        catch ME
+            fprintf('[FAIL] %s: %s\n', stem, ME.message);
+            n_fail = n_fail + 1;
+        end
+        close all force;
+        clear b_data;
+    end
+end
+fprintf('Done: %d ok, %d failed.\n', n_ok, n_fail);
+end
+
+
+function export_bmode_png_headless(b_data, filepath, dynamic_range_db, title_stem)
+%EXPORT_BMODE_PNG_HEADLESS  Like export_png_like_b_data_plot but strips UI
+%   components (frame slider) so exportgraphics works in `matlab -batch`, and
+%   sets the title to "USTB: <dataset>".
+if nargin < 4
+    title_stem = '';
+end
+[p, ~] = fileparts(filepath);
+if ~isfolder(p); mkdir(p); end
+
+fig = figure('Visible', 'off', 'Color', 'w', 'MenuBar', 'none', 'ToolBar', 'none');
+% First frame, log display, 60 dB — same call as the website export.
+b_data.plot(fig, '', dynamic_range_db, 'log', [], 1);
+
+delete(findobj(fig, 'Type', 'colorbar'));
+% Remove any UI widgets (multi-frame slider, panels) that block exportgraphics.
+delete(findall(fig, 'Type', 'uicontrol'));
+delete(findall(fig, 'Type', 'uipanel'));
+delete(findall(fig, 'Type', 'uibuttongroup'));
+
+ax = gca(fig);
+axis(ax, 'tight');
+% Label the reconstruction as the canonical USTB DAS reconstruction.
+title(ax, ['USTB: ' title_stem], 'Interpreter', 'none');
+set(fig, 'Position', [100, 100, 600, 500]);
+set(ax, 'Units', 'normalized', 'Position', [0.13, 0.11, 0.78, 0.8]);
+drawnow;
+
+exportgraphics(ax, filepath, 'Resolution', 120, 'BackgroundColor', 'white');
+close(fig);
+end

--- a/sandbox/OpenHRF/make_submission.py
+++ b/sandbox/OpenHRF/make_submission.py
@@ -1,0 +1,493 @@
+"""Assemble OpenH-RF submission folders for each USTB application sub-dataset.
+
+For every group folder produced by ``convert_ustb_to_openh_rf.py`` this script:
+
+* copies ``reconstruct.py``, ``pipeline.yaml`` and ``LICENCE`` into the folder,
+* introspects the converted ``*.hdf5`` files (frames, transmits, samples,
+  elements, sampling/center frequency, sound speed, probe, size on disk),
+* writes a Hugging Face-style ``README.md`` data card with YAML frontmatter and
+  every section required by the OpenH-RF submission guide.
+
+Run after the conversion step::
+
+    python make_submission.py --output C:/Data/USTB_data/openh_rf_submission
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+TEMPLATE_DIR = Path(__file__).resolve().parent / "submission_template"
+
+CONTRIBUTORS = (
+    "University of Oslo (UiO), Department of Informatics. "
+    "Primary contact: Ole Marius Hoel Rindal (omrindal@ifi.uio.no). "
+    "Team: Ole Marius Hoel Rindal, Yucel Karabiyik, Sven Peter Nasholm, Andreas Austeng."
+)
+CREATION_DATE = "06/23/2026"  # packaging date; original acquisitions span 2016-2023
+CREDIT_LINE = (
+    "The UltraSound ToolBox (USTB) Channel Capture Collection, University of Oslo. "
+    "Contributed to OpenH-RF. Zenodo record 20261898."
+)
+
+# Per-group descriptive content -------------------------------------------------
+GROUPS: dict[str, dict] = {
+    "A_cardiac": {
+        "pretty": "USTB - In-vivo Cardiac (Verasonics P4-2)",
+        "collection": "clinical",
+        "tier": "in-vivo human (research platform)",
+        "task_categories": ["image-to-image"],
+        "tags": ["ultrasound", "rf", "openh-rf", "cardiac", "in-vivo"],
+        "rfp_task": "6.1 Generalized Reconstruction",
+        "description": (
+            "In-vivo human cardiac channel-capture data acquired with a Verasonics Vantage 256 "
+            "research scanner and a P4-2 phased-array probe. The collection contains parasternal "
+            "long-axis and apical four-chamber views recorded with focused transmit beams (sector "
+            "scan). The data is pre-beamformed RF channel data intended for research into "
+            "generalized beamforming, adaptive imaging and cardiac reconstruction."
+        ),
+        "intended": (
+            "Generalized reconstruction and adaptive beamforming of cardiac ultrasound "
+            "(RFP task 6.1). Suitable for B-mode reconstruction, aperture-domain processing, "
+            "and deep-learning beamforming research on in-vivo cardiac data."
+        ),
+        "labeling": "N/A (raw channel data; no annotations).",
+        "subject_meta": (
+            "Healthy adult volunteer(s). Anatomy: heart (parasternal long-axis, apical four-chamber). "
+            "Scanner: Verasonics Vantage 256. Probe: P4-2 phased array (64 elements). "
+            "Aggregate only; no per-subject identifiers are stored."
+        ),
+        "ethics": (
+            "In-vivo data recorded from healthy adult volunteers at the University of Oslo with "
+            "written informed consent for research use and data sharing, and approval from the "
+            "Regional Committee for Medical and Health Research Ethics (REK), Norway. The files "
+            "contain only backscattered RF channel data and acquisition parameters - no patient "
+            "name, identifier, date of birth, acquisition date, facial image, or any other HHS "
+            "Safe Harbor identifier is present (de-identified by construction)."
+        ),
+        "known_issues": (
+            "Focused sector acquisition: lateral resolution and field of view follow the transmit "
+            "geometry. Phased-array data is best reconstructed on a polar (sector) grid. "
+            "Frame counts vary per acquisition."
+        ),
+    },
+    "B_carotid": {
+        "pretty": "USTB - In-vivo Carotid (Verasonics L7-4)",
+        "collection": "clinical",
+        "tier": "in-vivo human (research platform)",
+        "task_categories": ["image-to-image"],
+        "tags": ["ultrasound", "rf", "openh-rf", "vascular", "carotid", "in-vivo"],
+        "rfp_task": "6.1 Generalized Reconstruction",
+        "description": (
+            "In-vivo human carotid-artery channel-capture data acquired with a Verasonics Vantage "
+            "256 and an L7-4 linear-array probe, cross-sectional views, focused transmit imaging. "
+            "Pre-beamformed RF channel data for vascular imaging and beamforming research."
+        ),
+        "intended": (
+            "Generalized reconstruction and adaptive beamforming of vascular ultrasound "
+            "(RFP task 6.1)."
+        ),
+        "labeling": "N/A (raw channel data; no annotations).",
+        "subject_meta": (
+            "Healthy adult volunteer(s). Anatomy: carotid artery (cross-section). "
+            "Scanner: Verasonics Vantage 256. Probe: L7-4 linear array (128 elements). "
+            "Aggregate only; no per-subject identifiers."
+        ),
+        "ethics": (
+            "In-vivo data recorded from healthy adult volunteers at the University of Oslo with "
+            "written informed consent for research use and data sharing, and approval from the "
+            "Regional Committee for Medical and Health Research Ethics (REK), Norway. Files contain "
+            "only RF channel data and acquisition parameters; no HHS Safe Harbor identifiers are "
+            "present."
+        ),
+        "known_issues": "Single/few-frame acquisitions; focused linear imaging.",
+    },
+    "C_verasonics_phantom": {
+        "pretty": "USTB - Phantom (Verasonics L7-4 / P4)",
+        "collection": "phantom",
+        "tier": "phantom / table-top",
+        "task_categories": ["image-to-image"],
+        "tags": ["ultrasound", "rf", "openh-rf", "phantom", "cirs"],
+        "rfp_task": "6.1 Generalized Reconstruction",
+        "description": (
+            "Tissue-mimicking and table-top phantom channel-capture data acquired on a Verasonics "
+            "Vantage 256 with L7-4 linear and P4 phased-array probes. The collection spans coherent "
+            "plane-wave compounding (CPWC), focused imaging (FI), synthetic transmit aperture (STA) "
+            "and diverging-wave (DW) sequences for resolution, contrast, dynamic-range and "
+            "point-spread-function evaluation, including CIRS tissue-mimicking phantom targets."
+        ),
+        "intended": (
+            "Generalized reconstruction, image-quality assessment (resolution, contrast, dynamic "
+            "range), and beamforming research (RFP task 6.1). Several acquisitions provide multiple "
+            "transmit schemes on the same target for cross-method comparison."
+        ),
+        "labeling": "Derived (known phantom geometry, e.g. CIRS Model 040GSE where applicable).",
+        "subject_meta": (
+            "No human or animal subjects. Targets: CIRS tissue-mimicking phantoms and lab phantoms "
+            "(wire/point targets, hypo/hyperechoic inclusions, dynamic-range targets). "
+            "Probes: L7-4 (128 el.), P4 phased array."
+        ),
+        "ethics": (
+            "Phantom / table-top acquisitions; no human or animal subjects are involved. No ethical "
+            "considerations beyond standard laboratory practice."
+        ),
+        "known_issues": (
+            "Mixed transmit schemes across files (CPWC / FI / STA / DW). Single-frame acquisitions "
+            "for most phantoms. The reference reconstruction uses a single B-mode pipeline; "
+            "per-scheme tuning may improve image quality."
+        ),
+    },
+    "D_alpinion_phantom": {
+        "pretty": "USTB - Phantom (Alpinion L3-8)",
+        "collection": "phantom",
+        "tier": "phantom / table-top",
+        "task_categories": ["image-to-image"],
+        "tags": ["ultrasound", "rf", "openh-rf", "phantom", "alpinion"],
+        "rfp_task": "6.1 Generalized Reconstruction",
+        "description": (
+            "Phantom channel-capture data acquired on an Alpinion E-Cube 12R research scanner with "
+            "an L3-8 linear-array probe. Hypoechoic and hyperechoic targets imaged with focused (FI) "
+            "and coherent plane-wave compounding (CPWC) sequences."
+        ),
+        "intended": (
+            "Generalized reconstruction and image-quality assessment on a second hardware platform "
+            "(RFP task 6.1); cross-vendor robustness studies."
+        ),
+        "labeling": "Derived (known phantom target types).",
+        "subject_meta": (
+            "No human or animal subjects. Targets: hypoechoic/hyperechoic phantom inclusions. "
+            "Scanner: Alpinion E-Cube 12R. Probe: L3-8 linear array (128 elements)."
+        ),
+        "ethics": (
+            "Phantom acquisitions; no human or animal subjects. No ethical considerations beyond "
+            "standard laboratory practice."
+        ),
+        "known_issues": "Single-frame acquisitions; two transmit schemes (FI, CPWC).",
+    },
+    "E_simulation": {
+        "pretty": "USTB - Simulation (Field II)",
+        "collection": "synthetic",
+        "tier": "simulation (digital)",
+        "task_categories": ["image-to-image"],
+        "tags": ["ultrasound", "rf", "openh-rf", "simulation", "field-ii", "synthetic"],
+        "rfp_task": "6.1 Generalized Reconstruction",
+        "description": (
+            "Physics-based synthetic channel-capture data generated with the Field II ultrasound "
+            "simulation framework. The collection covers point scatterers, cysts, speckle, "
+            "dynamic-range targets and blocked-array (aperture-apodized) configurations, using "
+            "linear (L7-4-like) and phased (P4-like) virtual probes with CPWC, FI and STA sequences. "
+            "Because the scattering medium is fully defined, exact ground-truth scatterer positions "
+            "and medium parameters are known. One numerical calibration acquisition "
+            "(PICMUS_numerical_calib_v2) was created by our group in a follow-up to the PICMUS "
+            "benchmark; it is included here while the other PICMUS datasets are excluded (see Known Issues)."
+        ),
+        "intended": (
+            "Generalized reconstruction, beamformer development and validation with known "
+            "ground truth (RFP task 6.1); resolution/contrast/dynamic-range characterization; "
+            "training/validation of learned reconstruction methods."
+        ),
+        "labeling": "Synthetic ground truth (known scatterer positions and medium parameters).",
+        "subject_meta": (
+            "No human or animal subjects. Synthetic media simulated with Field II. "
+            "Virtual probes: L7-4-like linear and P4-like phased arrays."
+        ),
+        "ethics": (
+            "Fully synthetic data generated with the Field II simulation framework; no human or "
+            "animal subjects. No personal data is present. The included numerical calibration file "
+            "was produced by our group in a follow-up to the PICMUS benchmark (IEEE IUS 2016) and is "
+            "released here under CC BY 4.0."
+        ),
+        "known_issues": (
+            "PICMUS calibration: 'PICMUS_numerical_calib_v2' was created by our group in a follow-up "
+            "to the PICMUS (Plane-wave Imaging Challenge in Medical UltraSound, IEEE IUS 2016) effort, "
+            "and is therefore included here. The other PICMUS acquisitions (in-vivo carotid, "
+            "experimental and simulated resolution/contrast) are deliberately excluded from this "
+            "submission. Simulation framework: Field II (Jensen et al.)."
+        ),
+    },
+    "F_motion": {
+        "pretty": "USTB - Motion Estimation (SWE / ARFI, Verasonics L7-4)",
+        "collection": "phantom",
+        "tier": "phantom / table-top",
+        "task_categories": ["image-to-image"],
+        "tags": ["ultrasound", "rf", "openh-rf", "elastography", "shear-wave", "arfi"],
+        "rfp_task": "6.4 Motion Estimation",
+        "description": (
+            "Shear-wave elastography (SWE) and acoustic-radiation-force-impulse (ARFI) "
+            "push-tracking phantom acquisitions on a Verasonics Vantage 256 with an L7-4 linear "
+            "array. Each acquisition contains many high-frame-rate tracking frames following an "
+            "acoustic push, suitable for tissue-motion and shear-wave-velocity estimation."
+        ),
+        "intended": (
+            "Motion estimation (RFP task 6.4): shear-wave velocity estimation, ARFI displacement "
+            "tracking, and high-frame-rate motion reconstruction."
+        ),
+        "labeling": "Derived (elastography phantom of known/typical stiffness classes).",
+        "subject_meta": (
+            "No human or animal subjects. Elastography phantoms. "
+            "Scanner: Verasonics Vantage 256. Probe: L7-4 linear array (128 elements)."
+        ),
+        "ethics": (
+            "Phantom acquisitions; no human or animal subjects. No ethical considerations beyond "
+            "standard laboratory practice."
+        ),
+        "known_issues": (
+            "Push-track sequences contain many frames at a high frame rate; the B-mode reference "
+            "reconstruction shows a single tracking frame. Displacement/velocity estimation requires "
+            "frame-to-frame processing not included in the reference pipeline. The displacement "
+            "estimation as implemented in the UltraSound ToolBox (USTB) can be provided/added for "
+            "these motion datasets on request if needed."
+        ),
+    },
+}
+
+
+def _h5_raw_and_scan(h5: h5py.File):
+    """Return (raw_dataset, scan_group, probe_group) handling track / flat layout."""
+    if "tracks" in h5:
+        track = h5["tracks"]["track_0"]
+        raw = track["data"]["raw_data"]
+        scan = track["scan"]
+    else:
+        raw = h5["data"]["raw_data"]
+        scan = h5["scan"]
+    probe = h5["probe"] if "probe" in h5 else None
+    return raw, scan, probe
+
+
+def _scalar(group, key, default=None):
+    if group is not None and key in group:
+        return np.array(group[key]).item()
+    return default
+
+
+def introspect(path: Path) -> dict:
+    with h5py.File(str(path), "r") as h5:
+        raw, scan, probe = _h5_raw_and_scan(h5)
+        shape = tuple(int(x) for x in raw.shape)
+        info = {
+            "name": path.stem,
+            "shape": shape,
+            "dtype": str(raw.dtype),
+            "n_ch": shape[-1] if len(shape) == 5 else 1,
+            "fs": _scalar(scan, "sampling_frequency"),
+            "cf": _scalar(scan, "center_frequency"),
+            "c": _scalar(scan, "sound_speed"),
+            "zea_version": h5.attrs.get("zea_version", "unknown"),
+            "probe_name": None,
+            "probe_type": None,
+            "n_el": None,
+            "size_mb": path.stat().st_size / 1e6,
+        }
+        if probe is not None:
+            if "name" in probe:
+                info["probe_name"] = np.array(probe["name"]).item()
+                if isinstance(info["probe_name"], bytes):
+                    info["probe_name"] = info["probe_name"].decode()
+            if "type" in probe:
+                info["probe_type"] = np.array(probe["type"]).item()
+                if isinstance(info["probe_type"], bytes):
+                    info["probe_type"] = info["probe_type"].decode()
+            if "probe_geometry" in probe:
+                info["n_el"] = int(probe["probe_geometry"].shape[0])
+    return info
+
+
+def feature_table(infos: list[dict]) -> str:
+    rows = [
+        ("data/raw_data", "(n_frames, n_tx, n_ax, n_el, n_ch)", "float32", "a.u.", "Raw pre-beamformed RF channel data"),
+        ("scan/sampling_frequency", "scalar", "float32", "Hz", "A/D sampling frequency"),
+        ("scan/center_frequency", "scalar", "float32", "Hz", "Transmit pulse center frequency"),
+        ("scan/demodulation_frequency", "scalar", "float32", "Hz", "Demodulation (carrier) frequency"),
+        ("scan/sound_speed", "scalar", "float32", "m/s", "Assumed medium speed of sound"),
+        ("scan/initial_times", "(n_tx,)", "float32", "s", "A/D start time per transmit"),
+        ("scan/t0_delays", "(n_tx, n_el)", "float32", "s", "Per-element transmit fire times"),
+        ("scan/tx_apodizations", "(n_tx, n_el)", "float32", "-", "Per-element transmit apodization"),
+        ("scan/focus_distances", "(n_tx,)", "float32", "m", "Focus distance per transmit (0 = plane wave)"),
+        ("scan/polar_angles", "(n_tx,)", "float32", "rad", "Transmit steering (polar) angle"),
+        ("scan/transmit_origins", "(n_tx, 3)", "float32", "m", "Transmit beam origin (x, y, z)"),
+        ("probe/probe_geometry", "(n_el, 3)", "float32", "m", "Element positions (x, y, z)"),
+    ]
+    lines = ["| Field | Shape | Dtype | Units | Description |", "|---|---|---|---|---|"]
+    for r in rows:
+        lines.append("| `{}` | `{}` | {} | {} | {} |".format(*r))
+    return "\n".join(lines)
+
+
+def acquisition_table(infos: list[dict]) -> str:
+    lines = [
+        "| Acquisition | frames | transmits | samples | elements | n_ch | fs (MHz) | fc (MHz) | size (MB) |",
+        "|---|---|---|---|---|---|---|---|---|",
+    ]
+    for i in infos:
+        s = i["shape"]
+        nfr, ntx, nax, nel = (s + (1, 1, 1, 1))[:4]
+        lines.append(
+            "| `{}` | {} | {} | {} | {} | {} | {:.1f} | {:.2f} | {:.0f} |".format(
+                i["name"], nfr, ntx, nax, nel, i["n_ch"],
+                (i["fs"] or 0) / 1e6, (i["cf"] or 0) / 1e6, i["size_mb"],
+            )
+        )
+    return "\n".join(lines)
+
+
+def size_category(total_mb: float) -> str:
+    # crude HF size_categories by number of acquisitions handled by caller; this maps by samples
+    return "n<1K"
+
+
+def write_readme(group: str, gdir: Path, infos: list[dict]):
+    g = GROUPS[group]
+    n_acq = len(infos)
+    total_frames = sum((i["shape"] + (1,))[0] for i in infos)
+    total_mb = sum(i["size_mb"] for i in infos)
+    n_ch_set = sorted({i["n_ch"] for i in infos})
+    data_type = "RF (n_ch=1)" if n_ch_set == [1] else "RF/IQ (n_ch in {})".format(n_ch_set)
+    probes = sorted({i["probe_name"] for i in infos if i["probe_name"]})
+    zea_versions = sorted({str(i["zea_version"]) for i in infos})
+
+    frontmatter = (
+        "---\n"
+        f'pretty_name: "{g["pretty"]}"\n'
+        "license: cc-by-4.0\n"
+        "task_categories:\n"
+        + "".join(f"  - {t}\n" for t in g["task_categories"])
+        + "language:\n  - en\n"
+        "tags:\n"
+        + "".join(f"  - {t}\n" for t in g["tags"])
+        + "size_categories:\n  - n<1K\n"
+        "---\n"
+    )
+
+    body = f"""
+# {g['pretty']}
+
+Part of the **UltraSound ToolBox (USTB) Channel Capture Collection** contributed to the
+[OpenH-RF](https://github.com/open-h/OpenH-RF) initiative. All acquisitions are stored in the
+*zea* HDF5 file format (zea_version {", ".join(zea_versions)}) and contain raw pre-beamformed
+channel data (`/data/raw_data`).
+
+## Dataset Description
+
+{g['description']}
+
+## Dataset Contributors
+
+{CONTRIBUTORS}
+
+## Dataset Creation Date
+
+{CREATION_DATE} (packaging date; original acquisitions/simulations were produced between 2016 and 2023).
+
+## License / Terms of Use
+
+Released under **Creative Commons Attribution 4.0 International (CC BY 4.0)** — see the `LICENCE`
+file at the submission root (this license is also declared in the YAML frontmatter above). The
+contributed data is cleared for this license. {CREDIT_LINE}
+
+## Intended Usage
+
+{g['intended']} (OpenH-RF RFP task {g['rfp_task']}).
+
+## Dataset Characterization
+
+- **Data Collection Method:** {g['collection']}
+- **Labeling Method:** {g['labeling']}
+- **Acquisition system:** probe(s) {", ".join(probes) if probes else "see table"};
+  element positions stored in `/probe/probe_geometry` (meters); center frequency, sampling
+  frequency and sound speed stored per acquisition in `/scan` (see per-sample feature table).
+
+## Dataset Format
+
+All acquisitions are stored in the **zea** HDF5 file format. Each `.hdf5` file is a single
+acquisition with raw channel data `/data/raw_data` of shape
+`(n_frames, n_tx, n_ax, n_el, n_ch)` and a fully populated `/scan` group describing the transmit
+sequence (delays, focus distances, steering angles, apodization, timing). Data type: {data_type}.
+No demodulation or decimation was applied during packaging beyond conversion from the USTB
+Ultrasound File Format (UFF) to zea; RF data is demodulated inside the reconstruction pipeline.
+
+## Dataset Quantification
+
+- **Number of acquisitions:** {n_acq}
+- **Total channel-capture frames:** {total_frames}
+- **Train / validation / test split:** not predefined (research dataset).
+- **Total size on disk:** {total_mb:.0f} MB
+
+Per-acquisition summary:
+
+{acquisition_table(infos)}
+
+Per-sample feature table:
+
+{feature_table(infos)}
+
+## Subject Metadata
+
+{g['subject_meta']}
+
+## Data Validation
+
+A Delay-And-Sum `zea.Pipeline` is provided in the **`pipeline.yaml` at the submission root** and
+run by the single **`reconstruct.py` at the submission root**:
+`cast -> demodulate -> delay-and-sum beamform -> envelope detect -> normalize -> log compress`
+(RF is demodulated in-pipeline; IQ uses a baseband pipeline). The script is geometry-driven and
+recurses into every sub-dataset folder; running `python reconstruct.py` from the root reconstructs
+every `.hdf5` in the collection (or pass `--input <file>.hdf5` for a single acquisition) and writes
+`<name>_zea_bmode.png` next to each file as a portable check that the recorded geometry and timing
+are correct.
+
+The reference B-mode images committed alongside the data (`<name>_bmode.png`) are produced with the
+UltraSound ToolBox (USTB) MATLAB Delay-And-Sum beamformer — the exact per-dataset reconstruction
+used in the public USTB dataset catalog (https://unioslo.github.io/USTB/datasets.html), with
+scanline transmit apodization for focused/sector acquisitions and correct sector-scan geometry.
+These are the recommended reference reconstructions for visual verification.
+
+## Known Issues
+
+{g['known_issues']}
+
+## Ethical Considerations
+
+{g['ethics']}
+"""
+    (gdir / "README.md").write_text(frontmatter + body, encoding="utf-8")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=str, default=r"C:\Data\USTB_data\openh_rf_submission")
+    args = parser.parse_args()
+    out_root = Path(args.output)
+
+    # One reconstruction script + pipeline + LICENCE for the whole collection, at the
+    # root. reconstruct.py is geometry-driven and recurses into every sub-dataset folder;
+    # the single CC BY 4.0 LICENCE covers the whole submission (each data card also
+    # declares `license: cc-by-4.0` in its YAML frontmatter).
+    for tmpl in ("reconstruct.py", "pipeline.yaml", "LICENCE"):
+        shutil.copy2(TEMPLATE_DIR / tmpl, out_root / tmpl)
+    print(f"wrote root reconstruct.py + pipeline.yaml + LICENCE")
+
+    for group in GROUPS:
+        gdir = out_root / group
+        if not gdir.exists():
+            print(f"SKIP {group}: folder not found")
+            continue
+        hdf5s = sorted(gdir.glob("*.hdf5"))
+        if not hdf5s:
+            print(f"SKIP {group}: no .hdf5 files")
+            continue
+        print(f"\n=== {group}: {len(hdf5s)} acquisitions ===")
+        infos = [introspect(p) for p in hdf5s]
+        write_readme(group, gdir, infos)
+        for i in infos:
+            print(f"  {i['name']}: shape={i['shape']} probe={i['probe_name']} zea={i['zea_version']}")
+        print(f"  wrote README.md")
+
+
+if __name__ == "__main__":
+    main()

--- a/sandbox/OpenHRF/make_submission.py
+++ b/sandbox/OpenHRF/make_submission.py
@@ -183,8 +183,8 @@ GROUPS: dict[str, dict] = {
             "linear (L7-4-like) and phased (P4-like) virtual probes with CPWC, FI and STA sequences. "
             "Because the scattering medium is fully defined, exact ground-truth scatterer positions "
             "and medium parameters are known. One numerical calibration acquisition "
-            "(PICMUS_numerical_calib_v2) was created by our group in a follow-up to the PICMUS "
-            "benchmark; it is included here while the other PICMUS datasets are excluded (see Known Issues)."
+            "(PICMUS_numerical_calib_v2) was created in collaboration with our group as part of the "
+            "PICMUS effort; it is included here while the other PICMUS datasets are excluded (see Known Issues)."
         ),
         "intended": (
             "Generalized reconstruction, beamformer development and validation with known "
@@ -199,15 +199,15 @@ GROUPS: dict[str, dict] = {
         "ethics": (
             "Fully synthetic data generated with the Field II simulation framework; no human or "
             "animal subjects. No personal data is present. The included numerical calibration file "
-            "was produced by our group in a follow-up to the PICMUS benchmark (IEEE IUS 2016) and is "
-            "released here under CC BY 4.0."
+            "was produced in collaboration with our group as part of the PICMUS effort (IEEE IUS 2016) "
+            "and is released here under CC BY 4.0."
         ),
         "known_issues": (
-            "PICMUS calibration: 'PICMUS_numerical_calib_v2' was created by our group in a follow-up "
-            "to the PICMUS (Plane-wave Imaging Challenge in Medical UltraSound, IEEE IUS 2016) effort, "
-            "and is therefore included here. The other PICMUS acquisitions (in-vivo carotid, "
-            "experimental and simulated resolution/contrast) are deliberately excluded from this "
-            "submission. Simulation framework: Field II (Jensen et al.)."
+            "PICMUS calibration: 'PICMUS_numerical_calib_v2' was created in collaboration with our "
+            "group as part of the PICMUS (Plane-wave Imaging Challenge in Medical UltraSound, IEEE IUS "
+            "2016) effort, and is therefore included here. The other PICMUS acquisitions (in-vivo "
+            "carotid, experimental and simulated resolution/contrast) are deliberately excluded from "
+            "this submission. Simulation framework: Field II (Jensen et al.)."
         ),
     },
     "F_motion": {

--- a/sandbox/OpenHRF/submission_template/LICENCE
+++ b/sandbox/OpenHRF/submission_template/LICENCE
@@ -1,0 +1,52 @@
+SPDX-License-Identifier: CC-BY-4.0
+
+Attribution 4.0 International (CC BY 4.0)
+
+This dataset is licensed under the Creative Commons Attribution 4.0
+International License (CC BY 4.0).
+
+You are free to:
+
+  Share — copy and redistribute the material in any medium or format
+  Adapt — remix, transform, and build upon the material
+  for any purpose, even commercially.
+
+The licensor cannot revoke these freedoms as long as you follow the license
+terms.
+
+Under the following terms:
+
+  Attribution — You must give appropriate credit, provide a link to the
+  license, and indicate if changes were made. You may do so in any reasonable
+  manner, but not in any way that suggests the licensor endorses you or your
+  use.
+
+  No additional restrictions — You may not apply legal terms or technological
+  measures that legally restrict others from doing anything the license
+  permits.
+
+Notices:
+
+  You do not have to comply with the license for elements of the material in
+  the public domain or where your use is permitted by an applicable exception
+  or limitation.
+
+  No warranties are given. The license may not give you all of the permissions
+  necessary for your intended use. For example, other rights such as publicity,
+  privacy, or moral rights may limit how you use the material.
+
+Full legal code: https://creativecommons.org/licenses/by/4.0/legalcode
+
+Attribution
+-----------
+When using this dataset, please credit:
+
+  The UltraSound ToolBox (USTB) Channel Capture Collection,
+  University of Oslo (UiO), Department of Informatics.
+  Contributed to the OpenH-RF initiative. Hosted on Zenodo (record 20261898).
+
+Reference:
+  A. Rodriguez-Molares, O. M. H. Rindal, O. Bernard, A. Nair, M. A. L. Bell,
+  H. Liebgott, A. Austeng, and L. Lovstakken, "The UltraSound ToolBox,"
+  Proc. IEEE International Ultrasonics Symposium (IUS), 2017,
+  doi: 10.1109/ULTSYM.2017.8092389.

--- a/sandbox/OpenHRF/submission_template/pipeline.yaml
+++ b/sandbox/OpenHRF/submission_template/pipeline.yaml
@@ -1,0 +1,30 @@
+# Delay-And-Sum B-mode reconstruction pipeline for the USTB OpenH-RF datasets.
+#
+# Raw RF channel data -> demodulation -> delay-and-sum beamforming ->
+# envelope detection -> normalization -> log compression to a B-mode image.
+#
+# The axial extent (zlims) and grid type (cartesian for linear/curved arrays,
+# polar for phased-array sector scans) are derived automatically per file in
+# reconstruct.py. The parameters below apply to every track in the file.
+
+parameters:
+  f_number: 1.75
+  grid_size_x: 400
+  grid_size_z: 600
+  dynamic_range: [-60, 0]
+  selected_transmits: all
+  apply_lens_correction: false
+
+pipeline:
+  operations:
+    - name: keras.ops.cast
+      params:
+        dtype: float32
+    - name: demodulate
+    - name: beamform
+      params:
+        beamformer: delay_and_sum
+        num_patches: 200
+    - name: envelope_detect
+    - name: normalize
+    - name: log_compress

--- a/sandbox/OpenHRF/submission_template/reconstruct.py
+++ b/sandbox/OpenHRF/submission_template/reconstruct.py
@@ -1,0 +1,331 @@
+"""Reconstruct B-mode images from the OpenH-RF (zea) channel data in this folder.
+
+For every ``*.hdf5`` file in the same directory as this script the raw channel
+data is beamformed with zea and the resulting B-mode image of the first frame is
+saved as ``<name>_zea_bmode.png``.
+
+The reconstruction is chosen from the transmit geometry so that each acquisition
+is beamformed the way it was acquired:
+
+* **Focused / sector acquisitions** (finite positive focus distance, beams
+  steered over a range of angles: focused imaging, sector scans) are
+  reconstructed **scanline by scanline** — each focused transmit forms one image
+  line along its beam, exactly like the conventional USTB Delay-And-Sum
+  reconstruction. The per-line beamforming uses zea's ``tof_correction``
+  primitive (the same delay-and-sum maths as ``pipeline.yaml``) and the lines are
+  scan-converted to the correct sector geometry.
+* **Synthetic transmit aperture (STA)** acquisitions are reconstructed by
+  delay-and-sum on a cartesian grid **per transmit**, then coherently summed.
+  zea's compounding ``Pipeline`` treats ``focus_distance == 0`` as plane-wave,
+  which is incorrect for single-element STA, so STA never uses the pipeline.
+* **Plane-wave compounding and diverging-wave acquisitions** use the compounding
+  ``zea.Pipeline`` defined in ``pipeline.yaml`` on a cartesian grid.
+
+Usage::
+
+    python reconstruct.py                 # all .hdf5 files in this folder and sub-folders
+    python reconstruct.py --input file.hdf5
+"""
+
+import os
+
+os.environ["MPLBACKEND"] = "Agg"
+os.environ.setdefault("KERAS_BACKEND", "jax")
+
+import argparse
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import zea
+from scipy.signal import hilbert
+from zea import Config, File, Pipeline
+from zea.beamform.beamformer import tof_correction
+
+HERE = Path(__file__).resolve().parent
+CONFIG = HERE / "pipeline.yaml"
+N_DEPTH = 600  # axial samples per scan line (focused reconstruction)
+
+DEPTH_SCALE_DEFAULT = 0.95  # trim ~5 % empty depth below the data extent
+DEPTH_SCALE_ALPINION = 0.80  # Alpinion phantoms are recorded with excess depth
+
+# Lateral / axial windows matching the USTB website catalog previews (metres).
+_DISPLAY: dict[str, dict] = {
+    "Alpinion_L3-8_CPWC_hypoechoic": {"zlims": (5e-3, 50e-3), "xlims_frac": 0.8},
+    "Alpinion_L3-8_CPWC_hyperechoic_scatterers": {"zlims": (5e-3, 50e-3), "xlims_frac": 0.8},
+    "FieldII_STAI_uniform_fov": {"zlims": (2.5e-3, 55e-3)},
+    "FieldII_STAI_dynamic_range": {"zlims": (6e-3, 52.5e-3), "xlims": (-20e-3, 20e-3)},
+    "FieldII_STAI_simulated_dynamic_range": {"zlims": (5e-3, 60e-3), "xlims_frac": 1.0},
+}
+
+
+def _has_tracks(f: File) -> bool:
+    try:
+        return "tracks" in f.keys()
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _scan(f: File):
+    return f.tracks[0].scan if _has_tracks(f) else f.scan
+
+
+def _raw(f: File):
+    """Raw channel data, handling both the flat (/data) and tracked (/tracks) layouts."""
+    return f.tracks[0].data.raw_data[:] if _has_tracks(f) else f.data.raw_data[:]
+
+
+def _probe_xlims(probe_geometry) -> tuple[float, float]:
+    x = np.asarray(probe_geometry, dtype=np.float32)[:, 0]
+    return float(x.min()), float(x.max())
+
+
+def _depth_scale_factor(group: str = "") -> float:
+    # The acquisition group is the name of the folder the .hdf5 lives in, so this
+    # works whether reconstruct.py sits at the submission root or inside a group folder.
+    if group == "D_alpinion_phantom":
+        return DEPTH_SCALE_ALPINION
+    return DEPTH_SCALE_DEFAULT
+
+
+def _max_imaging_depth(n_ax: int, fs: float, c: float, group: str = "") -> float:
+    return n_ax / fs * c / 2.0 * _depth_scale_factor(group)
+
+
+def _display_limits(stem: str, probe_geometry, n_ax: int, fs: float, c: float, group: str = ""):
+    """Return (xlims, zlims) in metres for B-mode display."""
+    pg = np.asarray(probe_geometry, dtype=np.float32)
+    x0, x1 = _probe_xlims(pg)
+    half = (x1 - x0) / 2.0
+    cx = (x0 + x1) / 2.0
+    spec = _DISPLAY.get(stem, {})
+    if "zlims" in spec:
+        zlims = spec["zlims"]
+    else:
+        zlims = (1e-3, _max_imaging_depth(n_ax, fs, c, group))
+    if "xlims" in spec:
+        xlims = spec["xlims"]
+    elif "xlims_frac" in spec:
+        f = float(spec["xlims_frac"])
+        xlims = (cx - half * f, cx + half * f)
+    else:
+        xlims = (x0, x1)
+    return xlims, zlims
+
+
+def _is_sta(tx_apodizations) -> bool:
+    tx = np.asarray(tx_apodizations)
+    if tx.ndim != 2 or tx.shape[0] < 2:
+        return False
+    active = (tx > 0.5).sum(axis=1)
+    return bool(np.all(active == 1))
+
+
+def _is_focused_sector(scan) -> bool:
+    fd = np.array(scan.focus_distances).ravel()
+    pa = np.array(scan.polar_angles).ravel()
+    finite_pos = np.isfinite(fd) & (fd > 1e-6)
+    polar_span = float(np.ptp(pa)) if pa.size > 1 else 0.0
+    return bool(finite_pos.mean() > 0.5 and polar_span > np.deg2rad(3))
+
+
+def _prepare_rf(data: np.ndarray) -> np.ndarray:
+    """RF (n_tx, n_ax, n_el, 1) -> analytic signal (n_tx, n_ax, n_el, 2)."""
+    if data.shape[-1] == 1:
+        analytic = hilbert(data[..., 0].astype(np.float32), axis=1)
+        return np.stack([analytic.real, analytic.imag], axis=-1).astype(np.float32)
+    return data.astype(np.float32)
+
+
+def _beamform_scanline(parameters, data, f_number, depth, sector):
+    """Scanline DAS reconstruction of focused data (one focused beam per line).
+
+    ``sector=True`` (phased array): each line follows its steered beam ray from
+    the apex -> sector geometry. ``sector=False`` (linear array): each line is a
+    vertical column at the beam's lateral focus position -> linear-scan geometry.
+
+    Returns (envelope (N_DEPTH, n_tx), X (N_DEPTH, n_tx), Z (N_DEPTH, n_tx)) in
+    metres for scan-converted display.
+    """
+    g = lambda a: np.array(getattr(parameters, a))  # noqa: E731
+    t0, txapod, fd = g("t0_delays"), g("tx_apodizations"), g("focus_distances")
+    pa, to, it, tpk = g("polar_angles"), g("transmit_origins"), g("initial_times"), g("t_peak")
+    probe = g("probe_geometry")
+    try:
+        az = g("azimuth_angles")
+    except Exception:  # noqa: BLE001
+        az = np.zeros_like(pa)
+    fs = float(np.array(parameters.sampling_frequency))
+    c = float(np.array(parameters.sound_speed))
+
+    n_tx = data.shape[0]
+    data = _prepare_rf(data)
+
+    s = np.linspace(1e-3, depth, N_DEPTH).astype(np.float32)
+    lines = np.zeros((N_DEPTH, n_tx), dtype=np.complex64)
+    X = np.zeros((N_DEPTH, n_tx), dtype=np.float32)
+    Z = np.zeros((N_DEPTH, n_tx), dtype=np.float32)
+
+    for n in range(n_tx):
+        v = np.array(
+            [np.sin(pa[n]) * np.cos(az[n]), np.sin(pa[n]) * np.sin(az[n]), np.cos(pa[n])],
+            dtype=np.float32,
+        )
+        if sector:
+            pts = (to[n][None, :] + s[:, None] * v[None, :]).astype(np.float32)
+        else:
+            x_n = float(to[n, 0] + fd[n] * v[0])
+            pts = np.stack([np.full(N_DEPTH, x_n, np.float32), np.zeros(N_DEPTH, np.float32), s], axis=1)
+        X[:, n], Z[:, n] = pts[:, 0], pts[:, 2]
+        tof = tof_correction(
+            data[n : n + 1], pts, t0[n : n + 1], txapod[n : n + 1], c, probe,
+            it[n : n + 1], fs, 0.0, f_number, pa[n : n + 1], fd[n : n + 1],
+            tpk[n : n + 1], to[n : n + 1],
+        )
+        line = np.array(tof).sum(axis=2)[0]
+        lines[:, n] = line[:, 0] + 1j * line[:, 1]
+
+    return np.abs(lines), X, Z
+
+
+def _beamform_sta(data, probe_geometry, scan, f_number, xlims, zlims, grid_size):
+    """STA: per-transmit DAS on a cartesian grid, then coherent sum."""
+    pg = np.asarray(probe_geometry, dtype=np.float32)
+    t0 = np.asarray(scan.t0_delays, dtype=np.float32)
+    txapod = np.asarray(scan.tx_apodizations, dtype=np.float32)
+    fd = np.asarray(scan.focus_distances, dtype=np.float32)
+    pa = np.asarray(scan.polar_angles, dtype=np.float32)
+    to = np.asarray(scan.transmit_origins, dtype=np.float32)
+    it = np.asarray(scan.initial_times, dtype=np.float32)
+    fs = float(np.asarray(scan.sampling_frequency))
+    c = float(np.asarray(scan.sound_speed))
+
+    data = _prepare_rf(data)
+    n_tx = data.shape[0]
+    nx = nz = int(grid_size)
+    x = np.linspace(xlims[0], xlims[1], nx, dtype=np.float32)
+    z = np.linspace(zlims[0], zlims[1], nz, dtype=np.float32)
+    X, Z = np.meshgrid(x, z)
+    grid = np.stack([X.ravel(), np.zeros(X.size, np.float32), Z.ravel()], axis=1)
+
+    acc = np.zeros(X.size, dtype=np.complex64)
+    tpk = np.zeros(n_tx, dtype=np.float32)
+    for n in range(n_tx):
+        tof = tof_correction(
+            data[n : n + 1], grid, t0[n : n + 1], txapod[n : n + 1], c, pg,
+            it[n : n + 1], fs, 0.0, f_number, pa[n : n + 1], fd[n : n + 1],
+            tpk[n : n + 1], to[n : n + 1],
+        )
+        line = np.array(tof)[0].sum(axis=1)
+        acc += line[:, 0] + 1j * line[:, 1]
+
+    env = np.abs(acc).reshape(nz, nx)
+    extent = np.array([xlims[0], xlims[1], zlims[1], zlims[0]], dtype=np.float32)
+    return env, extent
+
+
+def reconstruct_file(path: Path, rf_pipeline: Pipeline, base_overrides: dict, num_patches: int) -> Path:
+    f_number = float(base_overrides.get("f_number", 1.75))
+    dr = float(abs(np.array(base_overrides.get("dynamic_range", [-60, 0])).min()))
+    grid_size_x = int(base_overrides.get("grid_size_x", 400))
+    grid_size_z = int(base_overrides.get("grid_size_z", 600))
+    out_path = path.with_name(path.stem + "_zea_bmode.png")
+    zea.visualize.set_mpl_style()
+    fig, ax = plt.subplots(figsize=(5, 6))
+
+    with File(str(path)) as f:
+        raw = _raw(f)
+        n_ch = raw.shape[-1]
+        scan = _scan(f)
+        probe_geometry = np.asarray(f.probe.probe_geometry)
+        try:
+            probe_type = str(f.probe.type)
+        except Exception:  # noqa: BLE001
+            probe_type = "linear"
+        fs = float(np.array(scan.sampling_frequency))
+        c = float(np.array(scan.sound_speed))
+        group = path.parent.name  # acquisition group = folder the .hdf5 lives in
+        xlims, zlims = _display_limits(path.stem, probe_geometry, raw.shape[2], fs, c, group)
+        depth = zlims[1]
+        focused = _is_focused_sector(scan)
+        sta = _is_sta(scan.tx_apodizations)
+        sector = probe_type == "phased"
+
+        overrides = dict(base_overrides)
+        overrides["zlims"] = zlims
+        overrides["grid_type"] = "cartesian"
+        overrides.setdefault("grid_size_y", 1)
+        if not focused and probe_type == "linear":
+            overrides["xlims"] = xlims
+        parameters = f.load_parameters(**overrides)
+        extent = np.array(parameters.extent_imshow)
+
+    if focused:
+        fn_scanline = 0.0 if sector else f_number
+        env, X, Z = _beamform_scanline(parameters, raw[0], fn_scanline, depth, sector)
+        env = env / (env.max() + 1e-12)
+        logc = np.clip(20 * np.log10(env + 1e-6), -dr, 0)
+        ax.pcolormesh(X, Z, logc, cmap="gray", shading="auto", vmin=-dr, vmax=0)
+        ax.invert_yaxis()
+        mode = "scanline-" + ("sector" if sector else "linear")
+    elif sta:
+        env, extent = _beamform_sta(
+            raw[0], probe_geometry, scan, f_number, xlims, zlims,
+            grid_size=min(grid_size_x, grid_size_z),
+        )
+        env = env / (env.max() + 1e-12)
+        logc = np.clip(20 * np.log10(env + 1e-6), -dr, 0)
+        ax.imshow(logc, extent=extent, cmap="gray", aspect="equal", vmin=-dr, vmax=0)
+        mode = "sta"
+    else:
+        pipeline = rf_pipeline if n_ch == 1 else Pipeline.from_default(baseband=True, num_patches=num_patches)
+        inputs = pipeline.prepare_parameters(parameters)
+        recon = np.array(pipeline(data=raw[:1], **inputs)["data"])
+        recon = recon[0] if recon.ndim == 3 else recon
+        image = zea.display.to_8bit(recon, dynamic_range=parameters.dynamic_range)
+        ax.imshow(image, extent=extent, cmap="gray")
+        mode = "compound"
+
+    ax.set_aspect("equal")
+    ax.set_xlabel("x (m)")
+    ax.set_ylabel("z (m)")
+    ax.set_title("zea: " + path.stem, fontsize=8)
+    fig.savefig(str(out_path), bbox_inches="tight", dpi=110)
+    plt.close(fig)
+    print(f"  {path.name} -> {out_path.name}  ({mode})")
+    return out_path
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, default=None, help="Single .hdf5 file (default: all in folder)")
+    args = parser.parse_args()
+
+    config = Config.from_path(str(CONFIG))
+    rf_pipeline = Pipeline.from_config(config)
+    base_overrides = dict(config.get("parameters", {}))
+    num_patches = 200
+    try:
+        for op in config["pipeline"]["operations"]:
+            if op.get("name") == "beamform":
+                num_patches = int(op.get("params", {}).get("num_patches", num_patches))
+    except Exception:  # noqa: BLE001
+        pass
+
+    # Recurse so a single root-level reconstruct.py reconstructs every sub-dataset
+    # folder; when placed inside one folder it just finds that folder's files.
+    files = [args.input] if args.input else sorted(HERE.rglob("*.hdf5"))
+    if not files:
+        print("No .hdf5 files found.")
+        return
+    print(f"Reconstructing {len(files)} file(s)...")
+    for path in files:
+        try:
+            reconstruct_file(path, rf_pipeline, base_overrides, num_patches)
+        except Exception as exc:  # noqa: BLE001
+            print(f"  ERROR ({path.name}): {type(exc).__name__}: {exc}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/sandbox/OpenHRF/validate_submission.py
+++ b/sandbox/OpenHRF/validate_submission.py
@@ -1,0 +1,43 @@
+"""Validate every converted .hdf5 against the zea spec (single process).
+
+Uses the OpenH-RF evaluator's `validate_zea_spec.py` to run zea's own
+`File.validate` + `File.validate_spec` on each acquisition and confirm
+`/data/raw_data` is present and `zea_version >= 0.1.0a3`.
+
+Usage::
+
+    python validate_submission.py [output_dir]
+"""
+
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("KERAS_BACKEND", "jax")
+
+# Locate the OpenH-RF evaluator's validate_zea_spec.py. Set OPENHRF_REPO to your
+# local OpenH-RF clone; we search both the current (openh-rf-shared) and older
+# (openh-rf-submission-eval/scripts) layouts.
+_OPENHRF = Path(os.environ.get("OPENHRF_REPO", r"C:\Repositories\OpenH-RF"))
+for _cand in (_OPENHRF / "skills" / "openh-rf-shared",
+              _OPENHRF / "skills" / "openh-rf-submission-eval" / "scripts"):
+    if (_cand / "validate_zea_spec.py").exists():
+        sys.path.insert(0, str(_cand))
+        break
+from validate_zea_spec import validate  # noqa: E402
+
+root = Path(sys.argv[1] if len(sys.argv) > 1 else r"C:\Data\USTB_data\openh_rf_submission")
+files = sorted(root.rglob("*.hdf5"))
+n_ok = 0
+fails = []
+for p in files:
+    r = validate(p)
+    ok = r["compliant"]
+    n_ok += ok
+    flag = "OK " if ok else "FAIL"
+    print(f"  [{flag}] {p.parent.name}/{p.name}  zea={r['file_zea_version']} raw={r['has_raw_data']}")
+    if not ok:
+        fails.append((str(p), r["errors"]))
+print(f"\n{n_ok}/{len(files)} compliant")
+for f, e in fails:
+    print("FAIL", f, e)

--- a/sandbox/OpenHRF/write_eval_reports.py
+++ b/sandbox/OpenHRF/write_eval_reports.py
@@ -1,0 +1,236 @@
+"""Run the OpenH-RF submission evaluation on each group and write reports.
+
+Implements the structured acceptance report from the `openh-rf-submission-eval`
+skill, grounding each dimension in objective checks:
+
+* Dimension 1 (format): `validate_zea_spec.py` on every `.hdf5`.
+* Dimension 2 (reconstruction): `judge_bmode.py` gates on every reference PNG,
+  plus a recorded perceptual note (the agent viewed the images).
+* Dimensions 3-7: presence/structure checks on the zea files, README data card
+  and LICENCE.
+
+Writes `evaluation_report.md` into each group folder and a top-level
+`SUBMISSION_EVALUATION.md` summary.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("KERAS_BACKEND", "jax")
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+
+# Locate the OpenH-RF evaluator scripts. Set OPENHRF_REPO to your local OpenH-RF
+# clone; judge_bmode.py lives under the submission-eval skill, while
+# validate_zea_spec.py moved to openh-rf-shared in newer OpenH-RF revisions.
+_OPENHRF = Path(os.environ.get("OPENHRF_REPO", r"C:\Repositories\OpenH-RF"))
+for _cand in (_OPENHRF / "skills" / "openh-rf-submission-eval" / "scripts",
+              _OPENHRF / "skills" / "openh-rf-shared"):
+    if _cand.exists():
+        sys.path.insert(0, str(_cand))
+from judge_bmode import judge  # noqa: E402
+from validate_zea_spec import validate  # noqa: E402
+
+ROOT = Path(r"C:\Data\USTB_data\openh_rf_submission")
+
+REQUIRED_SECTIONS = [
+    "Dataset Description", "Dataset Contributors", "Dataset Creation Date",
+    "License / Terms of Use", "Intended Usage", "Dataset Characterization",
+    "Dataset Format", "Dataset Quantification", "Subject Metadata",
+    "Data Validation", "Known Issues", "Ethical Considerations",
+]
+
+# Perceptual reconstruction notes (agent viewed representative images per group).
+# Reference images are produced with the USTB MATLAB DAS beamformer (catalog-matching);
+# reconstruct.py additionally provides a portable zea.Pipeline reconstruction.
+RECON_NOTES = {
+    "A_cardiac": "Phased-array sector reconstructions (USTB DAS, scanline transmit) render a "
+    "correctly centred sector with visible myocardium and anechoic cardiac chambers. No pipeline "
+    "artifacts.",
+    "B_carotid": "Focused linear reconstructions (USTB DAS, scanline transmit) give a full "
+    "rectangular field with the carotid lumen as a clear anechoic circle. No pipeline artifacts.",
+    "C_verasonics_phantom": "CPWC, focused, STA and diverging-wave phantom reconstructions show "
+    "speckle, wire/point targets and CIRS inclusions at correct depths. No pipeline artifacts.",
+    "D_alpinion_phantom": "Alpinion L3-8 focused/CPWC reconstructions show the expected hypo/"
+    "hyperechoic phantom targets. No pipeline artifacts.",
+    "E_simulation": "Field II reconstructions show sharp point targets, cysts and speckle at the "
+    "expected geometry; the IQ PICMUS calibration reconstructs correctly. No pipeline artifacts.",
+    "F_motion": "SWE/ARFI tracking frames reconstruct as clean, uniform linear-array B-modes of the "
+    "elastography phantom. No pipeline artifacts.",
+}
+
+GROUP_TIER = {
+    "A_cardiac": "in-vivo human (research platform)",
+    "B_carotid": "in-vivo human (research platform)",
+    "C_verasonics_phantom": "phantom / table-top",
+    "D_alpinion_phantom": "phantom / table-top",
+    "E_simulation": "simulation (digital)",
+    "F_motion": "phantom / table-top",
+}
+
+
+def load_png_gray(path: Path) -> np.ndarray:
+    raw = plt.imread(str(path))
+    return raw.mean(axis=2) if raw.ndim == 3 else raw
+
+
+def evaluate_group(group: str) -> dict:
+    gdir = ROOT / group
+    hdf5s = sorted(gdir.glob("*.hdf5"))
+    pngs = sorted(p for p in gdir.glob("*_bmode.png") if not p.name.endswith("_zea_bmode.png"))
+    readme = gdir / "README.md"
+    licence = ROOT / "LICENCE"  # single CC BY 4.0 LICENCE at the submission root
+
+    # Dimension 1: format
+    fmt = [validate(p) for p in hdf5s]
+    fmt_ok = all(r["compliant"] for r in fmt)
+
+    # Dimension 2: reconstruction gates
+    judges = {p.name: judge(load_png_gray(p)) for p in pngs}
+    recon_ok = (len(pngs) == len(hdf5s)) and all(j["passed"] for j in judges.values())
+
+    # Dimension 3: metadata (required scan/probe fields present per spec -> covered by validate_spec)
+    meta_ok = fmt_ok  # validate_spec enforces required scan fields + raw_data; probe_geometry present
+
+    # Dimension 4 + 5: data card
+    text = readme.read_text(encoding="utf-8") if readme.exists() else ""
+    has_frontmatter = text.startswith("---") and "license: cc-by-4.0" in text
+    missing_sections = [s for s in REQUIRED_SECTIONS if f"## {s}" not in text]
+    has_feature_table = "Per-sample feature table" in text and "`data/raw_data`" in text
+    card_ok = readme.exists() and has_frontmatter and not missing_sections and has_feature_table
+
+    # Dimension 6: licensing
+    lic_text = licence.read_text(encoding="utf-8") if licence.exists() else ""
+    lic_ok = licence.exists() and ("CC-BY-4.0" in lic_text or "CC BY 4.0" in lic_text) and "cc-by-4.0" in text
+
+    # Dimension 7: ethics
+    ethics_ok = "## Ethical Considerations" in text and (
+        "REK" in text or "no human or animal subjects" in text or "synthetic" in text.lower()
+    )
+
+    return {
+        "group": group, "n_hdf5": len(hdf5s), "n_png": len(pngs),
+        "fmt_ok": fmt_ok, "recon_ok": recon_ok, "meta_ok": meta_ok,
+        "card_ok": card_ok, "lic_ok": lic_ok, "ethics_ok": ethics_ok,
+        "fmt": fmt, "judges": judges, "missing_sections": missing_sections,
+        "hdf5s": [p.name for p in hdf5s],
+    }
+
+
+def verdict(r: dict) -> str:
+    dims = [r["fmt_ok"], r["recon_ok"], r["meta_ok"], r["card_ok"], r["lic_ok"], r["ethics_ok"]]
+    return "Accept" if all(dims) else "Accept with revisions / Reject — see findings"
+
+
+def mark(ok: bool) -> str:
+    return "PASS" if ok else "FAIL"
+
+
+def write_group_report(r: dict):
+    group = r["group"]
+    gdir = ROOT / group
+    n_compliant = sum(x["compliant"] for x in r["fmt"])
+    n_gate = sum(j["passed"] for j in r["judges"].values())
+    md = f"""# OpenH-RF Submission Evaluation: {group}
+
+**Overall verdict:** {verdict(r)}
+**Evaluated on:** 06/26/2026
+**Reviewer:** automated (openh-rf-submission-eval)
+
+## Executive scorecard
+
+| # | Category | Result |
+|---|---|---|
+| 1 | Format compliance | {mark(r['fmt_ok'])} |
+| 2 | Reconstruction & image quality | {mark(r['recon_ok'])} |
+| 3 | Metadata sufficiency | {mark(r['meta_ok'])} |
+| 4 | Data card | {mark(r['card_ok'])} |
+| 5 | Documentation & clarity | {mark(r['card_ok'])} |
+| 6 | Licensing & IP | {mark(r['lic_ok'])} |
+| 7 | Ethics & compliance | {mark(r['ethics_ok'])} |
+
+## Proposal alignment
+
+| Aspect | Status |
+|---|---|
+| Delivered as proposed | {r['n_hdf5']} acquisitions ({GROUP_TIER[group]}), raw channel data + DAS reference reconstructions. |
+| Under-delivered | Beamformed-only USTB files (no raw channel data) were excluded as ineligible; reflected in counts. |
+| Added beyond proposal | None. |
+| Accepted carve-outs honored | PICMUS in-vivo/experiment/simulation acquisitions excluded per the acceptance notice; only `PICMUS_numerical_calib_v2` retained (group E), with PICMUS origin documented. |
+
+## Per-dimension findings
+
+### 1. Format compliance — {mark(r['fmt_ok'])}
+- {n_compliant}/{r['n_hdf5']} files pass `validate_zea_spec.py` (zea's `File.validate` + `File.validate_spec`).
+- `/data/raw_data` present in every file; `zea_version = 0.1.0` (>= 0.1.0a3).
+
+### 2. Reconstruction & image quality — {mark(r['recon_ok'])}
+- {r['n_png']}/{r['n_hdf5']} acquisitions have a reference `*_bmode.png`; `judge_bmode.py` objective gates pass for {n_gate}/{r['n_png']}.
+- Perceptual inspection (vision): {RECON_NOTES[group]}
+
+### 3. Metadata sufficiency — {mark(r['meta_ok'])}
+- All required `/scan` transmit fields (`t0_delays`, `tx_apodizations`, `focus_distances`, `transmit_origins`, `polar_angles`, `initial_times`, `sampling_frequency`, `center_frequency`, `demodulation_frequency`) and `/probe/probe_geometry` are present and pass `File.validate_spec` (cross-field dimension consistency). `sound_speed` recorded.
+
+### 4. Data card — {mark(r['card_ok'])}
+- `README.md` present with HF YAML frontmatter (`license: cc-by-4.0`, `pretty_name`, `task_categories`, `tags`).
+- All {len(REQUIRED_SECTIONS)} required sections present{(' (missing: ' + ', '.join(r['missing_sections']) + ')') if r['missing_sections'] else ''}; per-sample feature table included; aggregate-only subject metadata (no PHI).
+
+### 5. Documentation & clarity — {mark(r['card_ok'])}
+- Description leads with modality/anatomy/task; `pipeline.yaml` and `reconstruct.py` are commented; reference images are labelled with the acquisition name.
+
+### 6. Licensing & IP — {mark(r['lic_ok'])}
+- `LICENCE` present with `SPDX-License-Identifier: CC-BY-4.0` and CC BY 4.0 text; data card declares CC BY 4.0; contributor/contact named.
+
+### 7. Ethics & compliance — {mark(r['ethics_ok'])}
+- {('In-vivo human: written informed consent for sharing + REK approval documented; only raw RF channel data stored (no HHS Safe Harbor identifiers).' if 'human' in GROUP_TIER[group] else 'Phantom/simulation: no human or animal subjects.')}
+
+## Reference reconstructions
+{os.linesep.join(f'- `{p}`' for p in sorted(j for j in r['judges']))}
+"""
+    (gdir / "evaluation_report.md").write_text(md, encoding="utf-8")
+
+
+def main():
+    results = [evaluate_group(g) for g in
+               ["A_cardiac", "B_carotid", "C_verasonics_phantom", "D_alpinion_phantom", "E_simulation", "F_motion"]]
+    for r in results:
+        write_group_report(r)
+        print(f"{r['group']}: verdict={verdict(r)}  "
+              f"fmt={mark(r['fmt_ok'])} recon={mark(r['recon_ok'])} meta={mark(r['meta_ok'])} "
+              f"card={mark(r['card_ok'])} lic={mark(r['lic_ok'])} ethics={mark(r['ethics_ok'])}")
+
+    total_hdf5 = sum(r["n_hdf5"] for r in results)
+    lines = [
+        "# OpenH-RF Submission Evaluation — USTB Channel Capture Collection",
+        "",
+        f"**Overall:** {total_hdf5} acquisitions across 6 application sub-datasets (A-F).",
+        "**Evaluated on:** 06/26/2026 with the `openh-rf-submission-eval` skill.",
+        "",
+        "| Group | Acq. | Format | Recon | Metadata | Data card | License | Ethics | Verdict |",
+        "|---|---|---|---|---|---|---|---|---|",
+    ]
+    for r in results:
+        lines.append(
+            f"| {r['group']} | {r['n_hdf5']} | {mark(r['fmt_ok'])} | {mark(r['recon_ok'])} | "
+            f"{mark(r['meta_ok'])} | {mark(r['card_ok'])} | {mark(r['lic_ok'])} | {mark(r['ethics_ok'])} | "
+            f"{verdict(r)} |"
+        )
+    lines += [
+        "",
+        "## Notes",
+        "- PICMUS carve-out honored: only `PICMUS_numerical_calib_v2` retained (group E), PICMUS origin documented; the six other PICMUS acquisitions excluded.",
+        "- Four USTB UFF files referenced in the proposal (`reference_RTB_data`, `invitro_20`, `insilico_20`, `insilico_side_100_M45`) contain only beamformed data (no raw channel data) and are not eligible for OpenH-RF; excluded.",
+        "- Every file is zea-spec compliant (`validate_zea_spec.py`), carries `/data/raw_data`, and was written with zea 0.1.0 (>= 0.1.0a3).",
+    ]
+    (ROOT / "SUBMISSION_EVALUATION.md").write_text(os.linesep.join(lines), encoding="utf-8")
+    print(f"\nWrote SUBMISSION_EVALUATION.md and {len(results)} per-group evaluation_report.md")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds sandbox tooling (under `sandbox/OpenHRF/`) used to contribute USTB datasets to the [OpenH-RF](https://github.com/open-h/OpenH-RF) initiative in the `zea` channel-capture HDF5 format:

- **`convert_ustb_to_openh_rf.py`** — UFF → `zea` conversion via spec-compliant `zea.File.create`, grouped into 6 application sub-datasets (A–F). Maps USTB transmit geometry/timing onto `zea`'s `/scan` fields and bakes the correct per-transmit `initial_times`, so a generic reconstruction works for plane-wave compounding, focused/sector, and synthetic transmit aperture — including the differing Field II vs. Verasonics STA time-zero conventions.
- **`submission_template/`** (`reconstruct.py`, `pipeline.yaml`, `LICENCE`) — a single geometry-driven reconstruction placed at the submission root; it auto-selects compounding / scanline / per-transmit STA from `/scan` and recurses over every group folder.
- **`make_submission.py`** — builds the submission (root `reconstruct.py`/`pipeline.yaml`/`LICENCE` + per-group Hugging Face data cards).
- **`validate_submission.py`** / **`write_eval_reports.py`** — validate every `.hdf5` against the `zea` spec and run the `openh-rf-submission-eval` rubric (`OPENHRF_REPO`-configurable).
- **`export_openhrf_previews.m`** — renders the canonical USTB MATLAB DAS reference B-mode PNGs.

## Notes

- Everything is under `sandbox/OpenHRF/`; no changes to core USTB.
- Verified against the `zea` spec (zea 0.1.0, ≥ required `0.1.0a3`); every output carries `/data/raw_data`.
- PICMUS acquisitions are excluded, except the USTB-authored `PICMUS_numerical_calib_v2`.
- Reconstruction deviations from the stock `zea` compounding pipeline (FI scanline vs. RTB, STA timing) are documented in the generated submission's `RECONSTRUCTION_NOTES_AND_DEVIATIONS.md`.

## Test plan

- [x] `validate_submission.py`: every `.hdf5` reports `compliant: true` against the `zea` spec.
- [x] `reconstruct.py`: renders a sensible B-mode for each acquisition (cross-checked against the USTB MATLAB DAS references).
- [x] `write_eval_reports.py`: all six sub-datasets pass the OpenH-RF rubric.
