### PR TITLE
Add Generalized Beamformer examples to website

### DIFF
--- a/sandbox/The_Generalized_Beamformer/TheGB_all_transmit_sequences.m
+++ b/sandbox/The_Generalized_Beamformer/TheGB_all_transmit_sequences.m
@@ -1,0 +1,139 @@
+%% The Generalized Beamformer: All Transmit Sequence Types
+%
+% This example demonstrates the Generalized Beamformer (GB) from the
+% UltraSound ToolBox (USTB). A single beamforming equation handles four
+% fundamentally different transmit sequences: plane wave, diverging wave,
+% single-element (STA), and focused imaging. Only the transmit delay model
+% and apodization parameters change between them.
+%
+% The results correspond to Figure 5 in:
+%   Rindal et al., "The Generalized Beamformer in the UltraSound ToolBox",
+%   Ultrasonics, 2026.
+%
+% _by Ole Marius Hoel Rindal <olemarius@olemarius.net>_
+
+clear all;
+close all;
+if strcmp(tools.headless_publish_figure_visible(), 'on')
+    set(groot, 'DefaultFigureVisible', 'on');
+end
+
+%% Dataset definitions
+% All four datasets were acquired on a Verasonics Vantage 256 using a
+% Philips L7-4 linear array (128 elements, 0.298 mm pitch, ~5.2 MHz center
+% frequency) and a CIRS 054GS phantom. The received channel data were
+% sampled at 20.8 MHz (4x center frequency).
+
+url = tools.zenodo_dataset_files_base();
+
+all_filenames{1} = 'L7_CPWC_TheGB.uff'; selected_tx(1) = 1;  tag{1} = 'PW';  tag_title{1} = 'Plane Wave';
+all_filenames{2} = 'L7_DW_TheGB.uff';   selected_tx(2) = 1;  tag{2} = 'DW';  tag_title{2} = 'Diverging Wave';
+all_filenames{3} = 'L7_STA_TheGB.uff';  selected_tx(3) = 32; tag{3} = 'STA'; tag_title{3} = 'Single Element (STA)';
+all_filenames{4} = 'L7_FI_TheGB.uff';   selected_tx(4) = 20; tag{4} = 'FI';  tag_title{4} = 'Focused';
+
+dynamic_range = 60;
+
+%% Download and beamform all four transmit types
+% Each dataset is beamformed using the GB in USTB (midprocess.das). The
+% only difference between the four is the transmit apodization and delay
+% model configuration. A constant f-number expanding receive aperture with
+% a Hamming window is used throughout.
+
+for f = 1:length(all_filenames)
+    filename = all_filenames{f};
+    tools.download(filename, url, data_path);
+    channel_data = uff.read_object([data_path filesep filename], '/channel_data');
+    channel_data.N_frames = 1;
+
+    if contains(filename, 'DW') || contains(filename, 'FI')
+        for seq = 1:channel_data.N_waves
+            channel_data.sequence(seq).sound_speed = channel_data.sound_speed;
+        end
+    end
+
+    scan = uff.linear_scan();
+    scan.x_axis = linspace(channel_data.probe.x(1), channel_data.probe.x(end), 512).';
+    scan.z_axis = linspace(3e-3, 50e-3, 512).';
+
+    %% Set up the Generalized Beamformer
+    mid = midprocess.das();
+    mid.dimension = dimension.receive;
+    mid.channel_data = channel_data;
+    mid.scan = scan;
+
+    if contains(filename, 'FI')
+        MLA = scan.N_x_axis / channel_data.N_waves;
+        mid.spherical_transmit_delay_model = spherical_transmit_delay_model.hybrid;
+        mid.pw_margin = 2/1000;
+        mid.transmit_apodization.window = uff.window.tukey25;
+        mid.transmit_apodization.f_number = 2.5;
+        mid.transmit_apodization.MLA = MLA;
+        mid.transmit_apodization.MLA_overlap = MLA;
+        mid.transmit_apodization.minimum_aperture = [2.5e-03 2.5e-03];
+    else
+        mid.transmit_apodization.window = uff.window.none;
+        mid.transmit_apodization.f_number = 1.7;
+    end
+
+    mid.receive_apodization.window = uff.window.hamming;
+    mid.receive_apodization.f_number = 1.7;
+
+    fprintf('\n=== Beamforming: %s (%d transmits) ===\n', tag_title{f}, channel_data.N_waves);
+    b_data_single_tx = mid.go();
+
+    b_data = uff.beamformed_data(b_data_single_tx);
+    b_data.data = reshape(b_data.data, size(b_data.data,1), 1, 1, size(b_data.data,3));
+
+    %% Single transmit image
+    % Showing a single transmit event before coherent compounding. This
+    % illustrates the raw contribution of one transmit to the final image.
+    tools.publish_beamformed_snap(b_data, ...
+        sprintf('%s - Single Transmit', tag_title{f}), dynamic_range, 'log', selected_tx(f));
+
+    %% Coherent compounding
+    % All transmit events are coherently summed to produce the final
+    % high-quality image. The GB handles this identically for all four
+    % transmit types.
+    cc = postprocess.coherent_compounding();
+    cc.input = b_data_single_tx;
+    b_data_CC = cc.go();
+
+    if contains(filename, 'FI')
+        tx_comp = sum(mid.transmit_apodization.data, 2);
+        b_data_CC.data = b_data_CC.data .* (1./tx_comp);
+    end
+
+    tools.publish_beamformed_snap(b_data_CC, ...
+        sprintf('%s - Compounded (%d Tx)', tag_title{f}, channel_data.N_waves), ...
+        dynamic_range, 'log');
+
+    img_single{f} = b_data;
+    img_compound{f} = b_data_CC;
+    n_tx(f) = channel_data.N_waves;
+end
+
+%% Summary: All compounded images
+% The four compounded images are shown side by side. Despite using
+% fundamentally different transmit wavefronts (plane, diverging, single
+% element, focused), the Generalized Beamformer produces comparable image
+% quality for all — demonstrating the unified nature of the approach.
+
+f_all = figure('Position', [100 100 1200 350]);
+for i = 1:4
+    img_compound{i}.plot(subplot(1,4,i), ...
+        sprintf('%s (%d Tx)', tag{i}, n_tx(i)), dynamic_range);
+end
+set(f_all, 'Color', 'w');
+tools.publish_snap_now_figure(f_all);
+
+%% Acquisition parameters
+% The table below summarizes the key acquisition parameters for each
+% transmit sequence type.
+
+fprintf('\n=== Acquisition Parameters ===\n');
+fprintf('%-12s  %8s  %12s  %8s\n', 'Type', 'N_Tx', 'fs (MHz)', 'Elements');
+fprintf('%s\n', repmat('-', 1, 50));
+for i = 1:4
+    fprintf('%-12s  %8d  %12.4f  %8d\n', tag{i}, n_tx(i), 20.8333, 128);
+end
+fprintf('\nAll sequences use f#=1.7 receive, Hamming window, 60 dB dynamic range.\n');

--- a/sandbox/The_Generalized_Beamformer/UFF_Verasonics_all.m
+++ b/sandbox/The_Generalized_Beamformer/UFF_Verasonics_all.m
@@ -7,13 +7,26 @@ close all;
 url = tools.zenodo_dataset_files_base();
 % if not found data will be downloaded from here
 
-% all_filenames{1}='L7_FI_TheGB.uff'; selected_tx(1) = 20; tag{1} = 'FI'; tag_title{1} = 'Focused';
-% all_filenames{2}='L7_DW_TheGB.uff'; selected_tx(2) = 1; tag{2} = 'DW'; tag_title{2} = 'Diverging';
-% all_filenames{3}='L7_CPWC_TheGB.uff'; selected_tx(3) = 1; tag{3} = 'PW'; tag_title{3} = 'Plane';
-% all_filenames{4}='L7_STA_TheGB.uff'; selected_tx(4) = 32; tag{4} = 'STA'; tag_title{4} = 'Single Element Diverging';
-%%
-all_filenames{1}='L7_DW_TheGB.uff'; selected_tx(1) = 1; tag{1} = 'DW'; tag_title{1} = 'Diverging';
-all_filenames{2}='L7_CPWC_TheGB.uff'; selected_tx(2) = 1; tag{2} = 'PW'; tag_title{2} = 'Plane';
+% Order matches Fig. 5 in the paper: (a) plane, (b) diverging,
+% (c) single diverging element (STA), (d) focused.
+all_filenames{1}='L7_CPWC_TheGB.uff'; selected_tx(1) = 1;  tag{1} = 'PW';  tag_title{1} = 'Plane';
+all_filenames{2}='L7_DW_TheGB.uff';   selected_tx(2) = 1;  tag{2} = 'DW';  tag_title{2} = 'Diverging';
+all_filenames{3}='L7_STA_TheGB.uff';  selected_tx(3) = 32; tag{3} = 'STA'; tag_title{3} = 'Single Element Diverging';
+all_filenames{4}='L7_FI_TheGB.uff';   selected_tx(4) = 20; tag{4} = 'FI';  tag_title{4} = 'Focused';
+
+% Common display settings so the two rows of Fig. 5 are identical in size.
+fig_position   = [638 434 480 520]; % aspect matched to scan (~30 mm x 47 mm) + label margin
+dynamic_range  = 60;                % dB, common color scale for all panels
+
+% Make sure the output folders exist before saving (saveas does not create them).
+output_dirs = {'figures/single_tx_illustrations', ...
+               'figures/compounded_images', ...
+               'figures/DelayCalculation'};
+for d = 1:numel(output_dirs)
+    if ~exist(output_dirs{d}, 'dir')
+        mkdir(output_dirs{d});
+    end
+end
 
 b_data_compare = uff.beamformed_data();
 
@@ -38,7 +51,7 @@ for f = 1:length(all_filenames)
     scan.z_axis = linspace(3e-3,50e-3,512).';
     scan.plot();
     title('Linear Scan');
-    %saveas(gcf,'Figures/linear_scan.png')
+    %saveas(gcf,'figures/linear_scan.png')
     %%
     %
     % and beamform
@@ -108,7 +121,22 @@ for f = 1:length(all_filenames)
     b_data.plot(subplot(5,1,[2:5]),['Single ',tag_title{f},' Transmit Image'],[],[],[],[selected_tx(f)]);
     colorbar off
     set(gcf,'Position',[659 87 581 891])
-    saveas(fig,['Figures/single_tx_illustrations/',tag{f},'.eps'],'eps2c')
+    % NOTE: the figure above (delay inset + image) is kept for reference only.
+
+    % ----- Standalone single-transmit B-mode image (Fig. 5 top row) -----
+    % Saved with the SAME figure size, color scale and axis labels as the
+    % coherent-compounded image below. Colorbar included on each panel.
+    %
+    % NB: plot into an explicit axes handle (not a figure handle) so USTB does
+    % NOT add the multi-frame slider uicontrol, which would make saveas/print
+    % fail with "UI components are not supported".
+    fig_tx = figure('Position',fig_position);
+    ax_tx  = axes(fig_tx);
+    b_data.plot(ax_tx,'',dynamic_range,[],[],[selected_tx(f)]);
+    caxis(ax_tx,[-dynamic_range 0]);
+    save_fig5_panel(fig_tx, ax_tx, ...
+        ['figures/single_tx_illustrations/',tag{f},'_redone.eps'], ...
+        true, true, ['(',char('a'+f-1),')']);  % top row: (a)-(d)
 
     %%
     b_data_illustrate_tx_delay = uff.beamformed_data(b_data);
@@ -127,7 +155,7 @@ for f = 1:length(all_filenames)
     colormap jet;
     cb = colorbar
     ylabel(cb,'Distance [mm]','FontSize',12)
-    saveas(fig,['Figures/DelayCalculation/rx_64.png'])
+    saveas(fig,['figures/DelayCalculation/rx_64.png'])
 
     %% Coherent Compounding
     cc = postprocess.coherent_compounding();
@@ -139,10 +167,13 @@ for f = 1:length(all_filenames)
         tx_comp = sum(mid.transmit_apodization.data,2);
         b_data_CC_postprocess.data = b_data_CC_postprocess.data.*(1./tx_comp);
     end
-    fig = figure();
-    b_data_CC_postprocess.plot(fig,['Coherent Compounded ',tag_title{f},' Transmit Image']);
-    set(gcf,'Position',[638 434 602 544])
-    saveas(fig,['Figures/compounded_images/',tag{f},'_compounded.eps'],'eps2c')
+    fig_cc = figure('Position',fig_position);
+    ax_cc  = axes(fig_cc);
+    b_data_CC_postprocess.plot(ax_cc,'',dynamic_range);
+    caxis(ax_cc,[-dynamic_range 0]);
+    save_fig5_panel(fig_cc, ax_cc, ...
+        ['figures/compounded_images/',tag{f},'_compounded_redone.eps'], ...
+        true, true, ['(',char('e'+f-1),')']);  % bottom row: (e)-(h)
 
    % ['/beamformed_data_',tag{f},'_SOS_',num2str(channel_data.sound_speed)]
    % b_data_CC_postprocess.write(['./compare_transmit_types','_SOS_',num2str(channel_data.sound_speed),'.uff'],['/beamformed_data_',tag{f}]);
@@ -156,3 +187,45 @@ end
 fig = figure();
 b_data_compare.plot(fig,['1=FI,2=DW,3=PW,4=STA']);
 b_data_compare.save_as_gif('no_compensation.gif');
+
+function save_fig5_panel(fig, ax, filepath, show_xlabel, show_ylabel, panel_label)
+%SAVE_FIG5_PANEL Export a tight Fig. 5 panel without title or colorbar.
+%
+% A white bold panel label (e.g. '(a)') is burned into the top-left corner of
+% the image itself, so it stays on the image regardless of the LaTeX layout.
+% All panels use the same normalized axes position so the image areas align in
+% LaTeX without trimming.
+
+    title(ax, '');
+
+    if show_xlabel
+        xlabel(ax, 'x [mm]');
+    else
+        xlabel(ax, '');
+        ax.XTickLabel = {};
+    end
+
+    if show_ylabel
+        ylabel(ax, 'z [mm]');
+    else
+        ylabel(ax, '');
+        ax.YTickLabel = {};
+    end
+
+    axis(ax, 'image');
+    colormap(ax, 'gray');
+    ax.Units = 'normalized';
+    ax.Position = [0.14 0.12 0.72 0.84];  % leave room for colorbar
+
+    colorbar(ax);
+
+    if nargin >= 6 && ~isempty(panel_label)
+        text(ax, 0.03, 0.955, panel_label, 'Units', 'normalized', ...
+            'Color', 'w', 'FontWeight', 'bold', 'FontSize', 14, ...
+            'HorizontalAlignment', 'left', 'VerticalAlignment', 'top');
+    end
+
+    set(fig, 'PaperPositionMode', 'auto');
+    set(fig, 'InvertHardcopy', 'off');
+    saveas(fig, filepath, 'eps2c');
+end

--- a/scripts/publish_all_publications.m
+++ b/scripts/publish_all_publications.m
@@ -16,6 +16,7 @@ addpath(genpath(ustb_root));
 % Each row: relative folder under publications/, absolute path to .m
 jobs = {
     'preprint/generalized_beamformer', fullfile(ustb_root, 'sandbox', 'The_Generalized_Beamformer', 'CPWC_double_adaptive_redone.m')
+    'preprint/generalized_beamformer', fullfile(ustb_root, 'sandbox', 'The_Generalized_Beamformer', 'TheGB_all_transmit_sequences.m')
     'TUSON/Vralstad_et_al_2026_Retrospective_transmit_correction_of_blocked_arrays', fullfile(ustb_root, 'publications', 'TUSON', 'Vralstad_et_al_2026_Retrospective_transmit_correction_of_blocked_arrays', 'Correction_of_simulated_blockage.m')
     'TUFFC/Dynamic_range_2020', fullfile(ustb_root, 'publications', 'DynamicRange', 'dynamic_range_test.m')
     'TUFFC/Prieur_fDMAS_2018', fullfile(ustb_root, 'publications', 'TUFFC', 'Prieur_et_al_Signal_coherence_and_image_amplitude_with_the_fDMAS', 'FI_UFF_FIeldII_simulations_Fig2_and_Fig3.m')

--- a/website/publications.html
+++ b/website/publications.html
@@ -52,14 +52,20 @@
 
         <p>The following publications have been produced using the USTB. Click &ldquo;Show published results&rdquo; to view the figures inline.</p>
 
-        <h2>Preprints</h2>
+        <h2>Ultrasonics</h2>
+        <p class="venue-note">Elsevier journal covering fundamental and applied ultrasonics.</p>
 
-        <p>Rindal, O. M. H., Rodriguez-Molares, A., Austeng, A. (2024). <em>The Generalized Beamformer.</em> TechRxiv preprint. <a href="https://www.techrxiv.org/users/684320/articles/1263073-the-generalized-beamformer-in-the-ultrasound-toolbox" target="_blank">doi:10.36227/techrxiv.1263073</a></p>
+        <h3>The Generalized Beamformer in the UltraSound ToolBox (2026, submitted)</h3>
+        <p>Rindal, O. M. H., Vr&aring;lstad, A. E., Rodriguez-Molares, A., Fiorentini, S., Avdal, J., Austeng, A. (2026). <em>The Generalized Beamformer in the UltraSound ToolBox.</em> Ultrasonics (submitted). Preprint: <a href="https://www.techrxiv.org/users/684320/articles/1263073-the-generalized-beamformer-in-the-ultrasound-toolbox" target="_blank">TechRxiv</a></p>
         <div class="pub-links">
             <a href="https://github.com/unioslo/USTB/tree/master/sandbox/The_Generalized_Beamformer" target="_blank">MATLAB code</a>
         </div>
         <details>
-            <summary>Show published results &darr;</summary>
+            <summary>Show all transmit sequences (Fig. 5) &darr;</summary>
+            <iframe class="pub-iframe" src="examples/publications/preprint/generalized_beamformer/TheGB_all_transmit_sequences.html"></iframe>
+        </details>
+        <details>
+            <summary>Show double adaptive beamforming (Fig. 7) &darr;</summary>
             <iframe class="pub-iframe" src="examples/publications/preprint/generalized_beamformer/CPWC_double_adaptive_redone.html"></iframe>
         </details>
 


### PR DESCRIPTION
## Summary
- Add publishable `TheGB_all_transmit_sequences.m` showcasing all four transmit types (PW, DW, STA, FI) with the Generalized Beamformer
- Register it in the publications publishing pipeline (`publish_all_publications.m`)
- Update `website/publications.html`: move entry from Preprints to Ultrasonics venue, add full author list, and embed both examples (all transmit sequences + double adaptive beamforming)
- Update `UFF_Verasonics_all.m` with latest figure-generation improvements (colorbars, consistent sizing)

## Context
This accompanies the paper submission: Rindal et al., 'The Generalized Beamformer in the UltraSound ToolBox', Ultrasonics, 2026.

## Test plan
- [ ] Run `publish_all_publications.m` to verify both scripts publish cleanly
- [ ] Check `website/publications.html` renders correctly with both iframes